### PR TITLE
Add `data-testid`s to the current components

### DIFF
--- a/packages/components/action_bar/src/action_bar.tsx
+++ b/packages/components/action_bar/src/action_bar.tsx
@@ -3,6 +3,7 @@ import { Flex, FlexProps } from "@buoysoftware/anchor-layout";
 
 interface OwnProps {
   children: React.ReactNode;
+  "data-testid"?: string;
 }
 
 type ActionBarProps = OwnProps & FlexProps;

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -1,3 +1,4 @@
+import kebabCase from "lodash/kebabCase";
 import { forwardRef } from "react";
 import { Heading } from "@buoysoftware/anchor-typography";
 import { Box, FlexProps } from "@buoysoftware/anchor-layout";
@@ -10,6 +11,7 @@ type IconPosition = "left" | "right";
 interface OwnProps {
   children: React.ReactNode;
   colorScheme?: ColorScheme;
+  "data-testid"?: string;
   disabled?: boolean;
   form?: string;
   icon?: React.ReactNode;
@@ -30,6 +32,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     {
       children,
       colorScheme = "basic",
+      "data-testid": testId,
       disabled,
       form,
       icon,
@@ -40,7 +43,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref
   ): React.ReactElement => (
-    <StyledButton disabled={disabled} form={form} onClick={onClick} ref={ref}>
+    <StyledButton
+      data-testid={testId}
+      disabled={disabled}
+      form={form}
+      onClick={onClick}
+      ref={ref}
+    >
       <InnerButton
         alignItems="center"
         borderRadius="4px"

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -1,4 +1,3 @@
-import kebabCase from "lodash/kebabCase";
 import { forwardRef } from "react";
 import { Heading } from "@buoysoftware/anchor-typography";
 import { Box, FlexProps } from "@buoysoftware/anchor-layout";

--- a/packages/components/dropdown_menu/src/dropdown_menu.tsx
+++ b/packages/components/dropdown_menu/src/dropdown_menu.tsx
@@ -1,3 +1,4 @@
+import kebabCase from "lodash/kebabCase";
 import { Button } from "@buoysoftware/anchor-button";
 import { ChevronDown } from "@styled-icons/feather";
 import { Popover, PopoverProps } from "react-tiny-popover";
@@ -5,6 +6,7 @@ import { useState } from "react";
 
 interface OwnProps {
   children: React.ReactNode;
+  "data-testid"?: string;
   label: string;
 }
 
@@ -14,9 +16,12 @@ const MENU_CONTAINER_OFFSET = 3;
 
 export const DropdownMenu: React.FC<DropdownMenuProps> = ({
   children,
+  "data-testid": testId,
   label,
   ...popoverProps
 }): React.ReactElement => {
+  const id = testId || kebabCase(`dropdown-menu-${label}`);
+
   const [isOpen, setIsOpen] = useState(false);
 
   const onClick = (e: React.MouseEvent): void => {
@@ -36,6 +41,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
       {...popoverProps}
     >
       <Button
+        data-testid={id}
         icon={<ChevronDown size="20px" strokeWidth="2px" />}
         iconPosition="right"
         onClick={onClick}

--- a/packages/components/nav/src/nav.tsx
+++ b/packages/components/nav/src/nav.tsx
@@ -16,6 +16,7 @@ export const Nav = styled(({ variant, ...props }) => {
       as="nav"
       alignItems="center"
       bg="white"
+      data-testid={`${variant}-navigation-bar`}
       display="flex"
       height="navigationBar"
       px="page.gutterX"


### PR DESCRIPTION
- Action bar was pretty bare bones so I just left it as a non required data-testid
- Button & dropdown menu I gave default identifiers but we can override if needed
- Nav has no default but is dynamic based on variant

<img width="1344" alt="Screenshot 2023-01-16 at 1 21 26 PM" src="https://user-images.githubusercontent.com/43525061/212745108-5f2d1e70-1ab1-4119-b190-62bf961da32c.png">
<img width="1381" alt="Screenshot 2023-01-16 at 1 21 17 PM" src="https://user-images.githubusercontent.com/43525061/212745116-6a03427b-1b17-4448-b297-6e5ac10e2a37.png">
