### PR TITLE
Introduce anchor default translations

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
   "npmClient": "yarn",
-  "version": "0.13.0"
+  "version": "0.13.1-alpha.0"
 }

--- a/packages/anchor-ui/package.json
+++ b/packages/anchor-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@buoysoftware/anchor-ui",
   "author": "Damian Galarza <damian@buoysoftware.com>",
-  "version": "0.13.0",
+  "version": "0.13.1-alpha.0",
   "homepage": "https://github.com/BuoySoftware/anchor-ui",
   "main": "src/index.ts",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "@buoysoftware/anchor-action-bar": "^0.13.0",
     "@buoysoftware/anchor-button": "^0.13.0",
     "@buoysoftware/anchor-dropdown-menu": "^0.13.0",
-    "@buoysoftware/anchor-form": "^0.13.0",
+    "@buoysoftware/anchor-form": "^0.13.1-alpha.0",
     "@buoysoftware/anchor-layout": "^0.13.0",
     "@buoysoftware/anchor-nav": "^0.13.0",
     "@buoysoftware/anchor-sticky-footer": "*",

--- a/packages/components/form/package.json
+++ b/packages/components/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buoysoftware/anchor-form",
-  "version": "0.13.0",
+  "version": "0.13.1-alpha.0",
   "main": "src/index.ts",
   "license": "MIT",
   "files": [

--- a/packages/components/form/specs/field_error.spec.tsx
+++ b/packages/components/form/specs/field_error.spec.tsx
@@ -2,7 +2,7 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import { render } from "@testing-library/react";
 
-import { FormScopeProvider } from "../src";
+import { anchorFormsEn, FormScopeProvider } from "../src";
 import { FieldError } from "../src/field_error";
 
 describe("<FieldError />", () => {
@@ -34,15 +34,18 @@ describe("<FieldError />", () => {
     },
   };
 
-  i18n.use(initReactI18next).init({
-    lng: "en",
-    ns: ["forms", "customScope"],
-    resources: {
-      en: {
-        customScope: customScopeTranslations,
-        forms: translations,
+  beforeEach(() => {
+    i18n.use(initReactI18next).init({
+      lng: "en",
+      ns: ["anchorForms", "customScope", "forms"],
+      resources: {
+        en: {
+          anchorForms: anchorFormsEn,
+          customScope: customScopeTranslations,
+          forms: translations,
+        },
       },
-    },
+    });
   });
 
   context("error is undefined", () => {
@@ -133,6 +136,25 @@ describe("<FieldError />", () => {
           "Custom scoped required error"
         );
       });
+
+      it("properly falls back if custom namespace does not have a translation", () => {
+        const errors = render(
+          <FormScopeProvider
+            value={{ scope: "testForm", tNamespace: ["customScope"] }}
+          >
+            <FieldError
+              name="fieldB"
+              inputType="text"
+              error={{ type: "required", message: "" }}
+              inputId="test-input"
+            />
+          </FormScopeProvider>
+        );
+
+        expect(errors.getByTestId("error-test-input")).toHaveTextContent(
+          "Default text input required message"
+        );
+      });
     });
 
     context("input type message exists", () => {
@@ -150,6 +172,26 @@ describe("<FieldError />", () => {
 
         expect(errors.getByTestId("error-test-input")).toHaveTextContent(
           "Default text input required message"
+        );
+      });
+    });
+
+    context("input type in anchor defaults exist", () => {
+      it("uses the anchor default", () => {
+        i18n.removeResourceBundle("en", "forms");
+        const errors = render(
+          <FormScopeProvider value={{ scope: "testForm" }}>
+            <FieldError
+              name="testField2"
+              inputType="text"
+              error={{ type: "required", message: "" }}
+              inputId="test-input"
+            />
+          </FormScopeProvider>
+        );
+
+        expect(errors.getByTestId("error-test-input")).toHaveTextContent(
+          "This field is required"
         );
       });
     });
@@ -175,6 +217,7 @@ describe("<FieldError />", () => {
   context("error message with markdown", () => {
     context("with a single message", () => {
       it("renders the provided message with markup", () => {
+        i18n;
         const errors = render(
           <FieldError
             name="myField"

--- a/packages/components/form/src/i18n/anchorForms.en.json
+++ b/packages/components/form/src/i18n/anchorForms.en.json
@@ -1,0 +1,27 @@
+{
+  "errors": {
+    "date": "Invalid date",
+    "dateNotInFuture": "Date cannot be in the future",
+    "invalidUnitControlNumber": "Invalid unit control number",
+    "invalidNumber": "Invalid number",
+    "maxLength": "Value is too long",
+    "minLength": "Value is too short",
+    "input_types": {
+      "checkbox": {
+        "required": "This field is required"
+      },
+      "collection_checkbox": {
+        "required": "A selection is required"
+      },
+      "text": {
+        "required": "This field is required"
+      },
+      "radio": {
+        "required": "This field is required, please make a selection"
+      },
+      "select": {
+        "required": "This field is required, please make a selection"
+      }
+    }
+  }
+}

--- a/packages/components/form/src/index.ts
+++ b/packages/components/form/src/index.ts
@@ -3,3 +3,5 @@ export * from "./form_scope_provider";
 export * from "./label";
 export * from "./radio_field";
 export * from "./use_form_field";
+
+export { default as anchorFormsEn } from "./i18n/anchorForms.en.json";

--- a/packages/components/form/stories/introduction.stories.mdx
+++ b/packages/components/form/stories/introduction.stories.mdx
@@ -16,7 +16,7 @@ React Hook Form works.
 
 Our library utilizes the power of [react-i18next] to do look ups for labels,
 placeholders, and errors. The assumption is that these translations exist within
-the namespace called 'forms'.
+the namespace called 'forms' or a namespace called `anchorForms`.
 
 ```
 {
@@ -41,6 +41,27 @@ the namespace called 'forms'.
     }
   }
 }
+```
+
+### Default translations
+
+AnchorUI provides some default translations for use within forms. To utilize them
+you must import the translations and add them as a resource in i18next.
+
+Example:
+
+```javascript
+import { anchorFormsEn } from "@buoysoftware/anchor-ui";
+
+i18n.use(initReactI18next).init({
+  lng: "en",
+  ns: ["anchorForms"],
+  resources: {
+    en: {
+      anchorForms: anchorFormsEn
+    }
+  }
+});
 ```
 
 [react-hook-form]: https://react-hook-form.com/


### PR DESCRIPTION
Fixes issue with namespace fallbacks.

Originally I was under the impression that when providing multiple
namespaces to the `useTranslation` hook would set up a fallback order
for looking up translations. This is actually incorrect, the first
namespace provided will be the default.

This explodes the array of namespaces to build out a proper fallback
order between custom namespaces, the forms namespace, and a default
anchorForms namespace.