### PR TITLE
Add Submitting state for buttons

### DIFF
--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@buoysoftware/anchor-layout": "^0.13.0",
     "@buoysoftware/anchor-theme": "^0.13.0",
-    "@buoysoftware/anchor-typography": "^0.13.0"
+    "@buoysoftware/anchor-typography": "^0.13.0",
+    "@buoysoftware/anchor-loading-indicator": "*"
   },
   "scripts": {
     "build": "tsc -outDir dist",

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -1,8 +1,9 @@
-import { forwardRef } from "react";
-import { Heading } from "@buoysoftware/anchor-typography";
 import { Box, FlexProps } from "@buoysoftware/anchor-layout";
 import { ColorScheme, InnerButton } from "./inner_button";
+import { Heading } from "@buoysoftware/anchor-typography";
+import { LoadingIndicator } from "@buoysoftware/anchor-loading-indicator";
 import { StyledButton } from "./styled_button";
+import { forwardRef } from "react";
 
 type Size = "s" | "l";
 type IconPosition = "left" | "right";
@@ -17,9 +18,12 @@ interface OwnProps {
   iconPosition?: IconPosition;
   onClick?: React.MouseEventHandler;
   size?: Size;
+  submitting?: boolean;
 }
 
-type ButtonProps = OwnProps & Omit<FlexProps, "theme" | "color" | "size">;
+type ButtonProps = OwnProps &
+  Omit<FlexProps, "theme" | "color" | "size"> &
+  React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 const HEIGHT_MAPPING: Record<Size, number> = {
   l: 40,
@@ -38,6 +42,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       iconPosition,
       onClick,
       size = "l",
+      submitting = false,
+      type,
       ...props
     },
     ref
@@ -48,28 +54,44 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       form={form}
       onClick={onClick}
       ref={ref}
+      type={type}
     >
       <InnerButton
         alignItems="center"
         borderRadius="4px"
         colorScheme={colorScheme}
-        disabled={disabled}
+        disabled={disabled || submitting}
         height={HEIGHT_MAPPING[size]}
         px={size}
         {...props}
       >
-        {iconPosition === "left" && (
-          <Box display="flex" ml="-xxs" mr="xs">
-            {icon}
-          </Box>
-        )}
-        <Heading as="span" color="inherit" size="s" textDecoration="none">
-          {children}
-        </Heading>
-        {iconPosition === "right" && (
-          <Box display="flex" ml="xs" mr="-xxs">
-            {icon}
-          </Box>
+        {type == "submit" && submitting ? (
+          <LoadingIndicator size="12px" strokeSize={1} color="text.tertiary" />
+        ) : (
+          <>
+            {iconPosition === "left" && (
+              <Box display="flex" ml="-xxs" mr="xs">
+                {icon}
+              </Box>
+            )}
+            {submitting && (
+              <Box display="flex" ml="-xxs" mr="xs">
+                <LoadingIndicator
+                  size="12px"
+                  strokeSize={1}
+                  color="text.tertiary"
+                />
+              </Box>
+            )}
+            <Heading as="span" color="inherit" size="s" textDecoration="none">
+              {children}
+            </Heading>
+            {iconPosition === "right" && (
+              <Box display="flex" ml="xs" mr="-xxs">
+                {icon}
+              </Box>
+            )}
+          </>
         )}
       </InnerButton>
     </StyledButton>

--- a/packages/components/button/src/styled_button.tsx
+++ b/packages/components/button/src/styled_button.tsx
@@ -2,7 +2,9 @@ import styled from "styled-components";
 
 import { boxCss, BoxProps } from "@buoysoftware/anchor-layout";
 
-export const StyledButton = styled.button<BoxProps>`
+type StyledButtonProps = BoxProps;
+
+export const StyledButton = styled.button<StyledButtonProps>`
   ${boxCss};
 
   margin: 0;

--- a/packages/components/button/stories/button.stories.mdx
+++ b/packages/components/button/stories/button.stories.mdx
@@ -6,12 +6,21 @@ import { Button } from "../src";
 <Meta
   title="Components / Button"
   component={Button}
+  argTypes={{
+    type: {
+      control: "select",
+      name: "type",
+      options: ["submit", "reset", "button"]
+    }
+  }}
   parameters={{
     controls: {
       include: [
         "disabled",
         "size",
-        "colorScheme"
+        "colorScheme",
+        "submitting",
+        "type"
       ]
     },
     layout: "centered"
@@ -41,7 +50,8 @@ import { Button } from "@buoysoftware/anchor-ui";
       disabled: false,
       size: "l",
       children: "Button",
-      colorScheme: "basic" 
+      colorScheme: "basic",
+      type: "submit"
     }}
   >
     {Template.bind({})}

--- a/packages/components/loading_indicator/clean-package.config.json
+++ b/packages/components/loading_indicator/clean-package.config.json
@@ -1,0 +1,6 @@
+{
+  "replace": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts"
+  }
+}

--- a/packages/components/loading_indicator/package.json
+++ b/packages/components/loading_indicator/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@buoysoftware/anchor-loading-indicator",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@buoysoftware/anchor-layout": "^0.13.0"
+  },
+  "scripts": {
+    "build": "tsc -outDir dist",
+    "compile": "tsc --noEmit",
+    "postpack": "clean-package restore",
+    "prepack": "clean-package"
+  }
+}

--- a/packages/components/loading_indicator/src/index.ts
+++ b/packages/components/loading_indicator/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./loading_indicator";

--- a/packages/components/loading_indicator/src/loading_indicator.tsx
+++ b/packages/components/loading_indicator/src/loading_indicator.tsx
@@ -1,0 +1,29 @@
+import styled, { keyframes } from "styled-components";
+import { themeGet } from "@styled-system/theme-get";
+import { Box, BoxProps } from "@buoysoftware/anchor-layout";
+
+const rotation = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+interface LoadingIndicatorProps
+  extends Omit<BoxProps, "color" | "size">,
+    Required<Pick<BoxProps, "color">>,
+    Required<Pick<BoxProps, "size">> {
+  strokeSize: number;
+}
+
+export const LoadingIndicator = styled(Box)<LoadingIndicatorProps>`
+  border: ${(props) => props.strokeSize}px solid
+    ${(props) => themeGet(props.color)};
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: ${rotation} 1s linear infinite;
+`;

--- a/packages/components/loading_indicator/stories/loading_indicator.stories.mdx
+++ b/packages/components/loading_indicator/stories/loading_indicator.stories.mdx
@@ -1,0 +1,23 @@
+import { Canvas, Story } from "@storybook/addon-docs";
+
+import { LoadingIndicator } from "../src";
+
+<Meta
+  title="Components / LoadingIndicator"
+  component={LoadingIndicator}
+  parameters={{
+    controls: {
+    },
+    layout: "centered"
+  }}
+/>
+
+export const Template = (args) => {
+  return <LoadingIndicator {...args} />
+};
+
+## Basic Usage
+
+<Canvas>
+  <Story name="LoadingIndicator" args={{ color: "grey70", size: "20px", strokeSize: 2}} >{Template.bind({})}</Story>
+</Canvas>

--- a/packages/components/loading_indicator/tsconfig.json
+++ b/packages/components/loading_indicator/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src", "index.ts", "../../../@types"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,31 +1149,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@buoysoftware/anchor-layout@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@buoysoftware/anchor-layout/-/anchor-layout-0.12.0.tgz#13bab63b87e96b2d4af2a9e3f44764769988dbef"
-  integrity sha512-aATnMOeBSOB1pe6dpsVCSMRRxH6oGJPXFeeO6SG7kUAE1qgU+ZsrUFw1RhjlONFQLtTpxLygS7+SgLpTzJ5gKw==
-  dependencies:
-    "@buoysoftware/anchor-theme" "^0.12.0"
-    styled-components "^5.3.6"
-    styled-system "^5.1.5"
-
-"@buoysoftware/anchor-sticky-footer@*":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@buoysoftware/anchor-sticky-footer/-/anchor-sticky-footer-0.12.0.tgz#a5799a68562eee5e799ac5df60eaf7e75696d8a3"
-  integrity sha512-jJbgcLAMLDLOAGv+0zdpADowW4vEr/KkU4u/Ya8y7IOJF1lM9k/F1BouWTD3YK0kqPuHGNAD4XMKKVhHf+KBcw==
-  dependencies:
-    "@buoysoftware/anchor-layout" "^0.12.0"
-
-"@buoysoftware/anchor-theme@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@buoysoftware/anchor-theme/-/anchor-theme-0.12.0.tgz#f7e942661f2f4bd80974f5a7408dbb3f7f5f6a1e"
-  integrity sha512-49Q6AmhH0eDxveDsSHD2tMuFW6RdT2ysEYrdKxxWFo4vtT51kU12oqQ6949qMD783KJbqmqwxaw8HorGV+rsDw==
-  dependencies:
-    "@styled-system/theme-get" "^5.1.2"
-    polished "^4.2.2"
-    styled-components "^5.3.6"
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"


### PR DESCRIPTION
This introduces a CSS based loading indicator via the `LoadingIndicator` component and utilizes for the button submitting state.

Whenever a button has the 'submitting' state as true, the button will be
disabled.

Buttons of type submit will hide their original context and display a
loading indicator instead.