### PR TITLE
Extract FooterActions component

### DIFF
--- a/packages/components/footer_actions/clean-package.config.json
+++ b/packages/components/footer_actions/clean-package.config.json
@@ -1,0 +1,6 @@
+{
+  "replace": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts"
+  }
+}

--- a/packages/components/footer_actions/package.json
+++ b/packages/components/footer_actions/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "@buoysoftware/anchor-sticky-footer",
-  "version": "0.18.0-alpha.0",
+  "name": "@buoysoftware/anchor-footer-actions",
+  "version": "0.0.0",
   "main": "src/index.ts",
   "license": "MIT",
-  "files": [
-    "dist"
-  ],
   "dependencies": {
-    "@buoysoftware/anchor-footer-actions": "*"
+    "@buoysoftware/anchor-layout": "^0.17.0"
   },
   "scripts": {
     "build": "tsc -outDir dist",

--- a/packages/components/footer_actions/src/footer_actions.tsx
+++ b/packages/components/footer_actions/src/footer_actions.tsx
@@ -1,0 +1,28 @@
+import { Flex, FlexProps } from "@buoysoftware/anchor-layout";
+
+interface OwnProps {
+  children?: React.ReactNode;
+}
+
+export type FooterActionsProps = OwnProps & FlexProps;
+
+export const FooterActions: React.FC<FooterActionsProps> = ({
+  children,
+  ...props
+}): React.ReactElement => {
+  return (
+    <Flex
+      alignItems="center"
+      as="footer"
+      borderTop="1SolidSubdued"
+      data-testid="footer-actions"
+      gap="m"
+      height="footerActions"
+      justifyContent="flex-end"
+      px="xxxl"
+      {...props}
+    >
+      {children}
+    </Flex>
+  );
+};

--- a/packages/components/footer_actions/src/index.ts
+++ b/packages/components/footer_actions/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./footer_actions";

--- a/packages/components/footer_actions/stories/footer_actions.stories.mdx
+++ b/packages/components/footer_actions/stories/footer_actions.stories.mdx
@@ -1,0 +1,40 @@
+import { Canvas, Story } from "@storybook/addon-docs";
+import { Box } from "@buoysoftware/anchor-layout";
+import { Button } from "@buoysoftware/anchor-button";
+
+import { FooterActions } from "../src";
+
+<Meta
+  title="Components / FooterActions"
+  component={FooterActions}
+  parameters={{
+    layout: "fullscreen"
+  }}
+/>
+
+export const Template = (args) => {
+  return (
+    <Box position="fixed" left={0} right={0} bottom={0}>
+      <FooterActions {...args}>
+        <Button size="l" colorScheme="basic">Cancel</Button>
+        <Button size="l" colorScheme="primary">Save</Button>
+      </FooterActions>
+    </Box>
+  );
+};
+
+# Footer
+
+## Import
+
+```javascript
+import { FooterActions } from "@buoysoftware/anchor-ui";
+```
+
+## Basic Usage
+
+<Canvas>
+  <Story name="FooterActions">
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/components/footer_actions/tsconfig.json
+++ b/packages/components/footer_actions/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src", "index.ts", "../../../@types"]
+}

--- a/packages/components/sticky_footer/src/sticky_footer.tsx
+++ b/packages/components/sticky_footer/src/sticky_footer.tsx
@@ -1,29 +1,23 @@
-import { Flex, FlexProps } from "@buoysoftware/anchor-layout";
+import {
+  FooterActions,
+  FooterActionsProps,
+} from "@buoysoftware/anchor-footer-actions";
 
-type StickyFooterProps = Omit<FlexProps, "height">;
-
-export const StickyFooter: React.FC<StickyFooterProps> = ({
+export const StickyFooter: React.FC<FooterActionsProps> = ({
   children,
   ...props
 }): React.ReactElement => {
   return (
-    <Flex
-      alignItems="center"
-      as="footer"
-      borderTop="1SolidSubdued"
+    <FooterActions
       bottom={0}
       data-testid="sticky-footer"
-      gap="m"
-      height="stickyFooter"
-      justifyContent="flex-end"
       left={0}
       position="fixed"
-      px="xxxl"
       right={0}
       zIndex="2"
       {...props}
     >
       {children}
-    </Flex>
+    </FooterActions>
   );
 };

--- a/packages/theme/src/sizes/base.ts
+++ b/packages/theme/src/sizes/base.ts
@@ -3,6 +3,7 @@ export const base = {
   checkboxWrapper: "18px",
   input: "350px",
   inputSmall: "141px",
+  footerActions: "80px",
   menu: "150px",
   modalWidth: "527px",
   modalWidthLarge: "880px",
@@ -11,7 +12,6 @@ export const base = {
   paymentStatusWidth: "425px",
   radio: "18px",
   searchInput: "220px",
-  stickyFooter: "80px",
   widget: "170px",
 };
 


### PR DESCRIPTION
This extracts the footer bar component out of the sticky footer for use elsewhere. With CSS grid we may remove the StickyFooter component all together. I'll wait until I've implemented a few components / pages to determine this.