### PR TITLE
Fix submitting disabled state in button

### DIFF
--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -50,7 +50,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ): React.ReactElement => (
     <StyledButton
       data-testid={testId}
-      disabled={disabled}
+      disabled={disabled || submitting}
       form={form}
       onClick={onClick}
       ref={ref}
@@ -60,7 +60,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         alignItems="center"
         borderRadius="4px"
         colorScheme={colorScheme}
-        disabled={disabled || submitting}
         height={HEIGHT_MAPPING[size]}
         px={size}
         {...props}

--- a/packages/components/button/src/inner_button.tsx
+++ b/packages/components/button/src/inner_button.tsx
@@ -83,7 +83,7 @@ export const InnerButton = styled(Flex)<InnerButtonProps>`
       getThemeColor(props.colorScheme, props.theme, "active")};
   }
 
-  &[disabled] {
+  [disabled] & {
     background-color: ${(props) =>
       getThemeColor(props.colorScheme, props.theme, "disabledBackground")};
 


### PR DESCRIPTION
Previously, I updated the InnerButton to include submitting as a qualifier for being disabled, this applied the styles to look like the button was disabled but did not actually disable the button because the button didn't have disabled applied properly.

This resolves the issue by allowing the button element itself be the source of truth for whether or not it's disabled and the styled inner button component uses nesting to properly style itself based off whether it is within a disabled button.