### PR TITLE
Introduce @buoysoftware/anchor-table

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,8 +11,7 @@
     "plugin:react/recommended",
     "plugin:jest/recommended",
     "plugin:jest-dom/recommended",
-    "plugin:react-hooks/recommended",
-    "prettier"
+    "plugin:react-hooks/recommended"
   ],
   "env": {
     "es6": true,

--- a/@types/Maybe.d.ts
+++ b/@types/Maybe.d.ts
@@ -1,0 +1,1 @@
+declare type Maybe<T> = T | null | undefined;

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "eslint-plugin-jest-dom": "^4.0.3",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "iconoir-react": "^6.0.0",
     "jest-environment-jsdom": "^29.3.1",
     "jest-plugin-context": "^2.9.0",
-    "iconoir-react": "^6.0.0",
     "lerna": "^6.1.0",
     "lodash": "^4.17.21",
     "ts-jest": "^29.0.3"

--- a/packages/anchor-ui/package.json
+++ b/packages/anchor-ui/package.json
@@ -25,6 +25,7 @@
     "@buoysoftware/anchor-nav": "^0.20.0",
     "@buoysoftware/anchor-page-template": "^0.20.0",
     "@buoysoftware/anchor-side-nav": "^0.20.0",
+    "@buoysoftware/anchor-table": " *",
     "@buoysoftware/anchor-theme": "^0.20.0",
     "@buoysoftware/anchor-typography": "^0.20.0",
     "@buoysoftware/anchor-use-translated-options": "^0.18.0"

--- a/packages/anchor-ui/src/index.ts
+++ b/packages/anchor-ui/src/index.ts
@@ -8,6 +8,7 @@ export * from "@buoysoftware/anchor-loading-indicator";
 export * from "@buoysoftware/anchor-nav";
 export * from "@buoysoftware/anchor-page-template";
 export * from "@buoysoftware/anchor-side-nav";
+export * from "@buoysoftware/anchor-table";
 export * from "@buoysoftware/anchor-theme";
 export * from "@buoysoftware/anchor-typography";
 export * from "@buoysoftware/anchor-use-translated-options";

--- a/packages/components/table/__specs__/__snapshots__/table.spec.tsx.snap
+++ b/packages/components/table/__specs__/__snapshots__/table.spec.tsx.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Table /> renders the table correctly 1`] = `
+<DocumentFragment>
+  <table
+    class="sc-hLBbgP dxfGUx"
+    data-testid="test-table-donations-table"
+  >
+    <thead
+      class="sc-pyfCe ecJMuD"
+    >
+      <tr>
+        <th
+          class="sc-bcXHqe sc-eDvSVe sc-gKPRtg bjZCcm cRpfjC"
+          color="text.primary"
+          font-size="font-size-100"
+          font-weight="600"
+        >
+          test_table_donations.th.id
+        </th>
+        <th
+          class="sc-bcXHqe sc-eDvSVe sc-gKPRtg bjZCcm cRpfjC"
+          color="text.primary"
+          font-size="font-size-100"
+          font-weight="600"
+        >
+          test_table_donations.th.status
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="sc-ftTHYK jdcCIu"
+    >
+      <tr
+        data-testid="tr-1"
+      >
+        <td
+          class="sc-bcXHqe sc-eDvSVe sc-jSUZER rcJCu lliSHS"
+          color="text.primary"
+          data-testid="tr-1-td-id"
+          font-size="font-size-100"
+          font-style="none"
+          font-weight="400"
+        >
+          1
+        </td>
+        <td
+          class="sc-bcXHqe sc-eDvSVe sc-jSUZER rcJCu lliSHS"
+          color="text.primary"
+          data-testid="tr-1-td-status"
+          font-size="font-size-100"
+          font-style="none"
+          font-weight="400"
+        >
+          Good
+        </td>
+      </tr>
+      <tr
+        data-testid="tr-2"
+      >
+        <td
+          class="sc-bcXHqe sc-eDvSVe sc-jSUZER rcJCu lliSHS"
+          color="text.primary"
+          data-testid="tr-2-td-id"
+          font-size="font-size-100"
+          font-style="none"
+          font-weight="400"
+        >
+          2
+        </td>
+        <td
+          class="sc-bcXHqe sc-eDvSVe sc-jSUZER rcJCu lliSHS"
+          color="text.primary"
+          data-testid="tr-2-td-status"
+          font-size="font-size-100"
+          font-style="none"
+          font-weight="400"
+        >
+          Bad
+        </td>
+      </tr>
+      <tr
+        data-testid="tr-3"
+      >
+        <td
+          class="sc-bcXHqe sc-eDvSVe sc-jSUZER rcJCu lliSHS"
+          color="text.primary"
+          data-testid="tr-3-td-id"
+          font-size="font-size-100"
+          font-style="none"
+          font-weight="400"
+        >
+          3
+        </td>
+        <td
+          class="sc-bcXHqe sc-eDvSVe sc-jSUZER rcJCu lliSHS"
+          color="text.primary"
+          data-testid="tr-3-td-status"
+          font-size="font-size-100"
+          font-style="none"
+          font-weight="400"
+        >
+          Ugly
+        </td>
+      </tr>
+      <tr
+        data-testid="tr-4"
+      >
+        <td
+          class="sc-bcXHqe sc-eDvSVe sc-jSUZER rcJCu lliSHS"
+          color="text.primary"
+          data-testid="tr-4-td-id"
+          font-size="font-size-100"
+          font-style="none"
+          font-weight="400"
+        >
+          4
+        </td>
+        <td
+          class="sc-bcXHqe sc-eDvSVe sc-jSUZER rcJCu lliSHS"
+          color="text.primary"
+          data-testid="tr-4-td-status"
+          font-size="font-size-100"
+          font-style="none"
+          font-weight="400"
+        >
+          Other
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</DocumentFragment>
+`;

--- a/packages/components/table/__specs__/table.spec.tsx
+++ b/packages/components/table/__specs__/table.spec.tsx
@@ -1,0 +1,185 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import { render as baseRender, RenderResult } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+import { theme } from "@buoysoftware/anchor-theme";
+
+import { TableCellConfig } from "../src/types";
+import { Table } from "../src/table";
+
+interface Donation {
+  __typename: string;
+  id: string;
+  status: string | null;
+}
+
+const records: Donation[] = [
+  { __typename: "Donation", id: "1", status: "Good" },
+  { __typename: "Donation", id: "2", status: "Bad" },
+  { __typename: "Donation", id: "3", status: "Ugly" },
+  { __typename: "Donation", id: "4", status: "Other" },
+];
+
+const cellConfigs: TableCellConfig<Donation>[] = [
+  { dataKey: "id" },
+  { dataKey: "status" },
+];
+
+describe("<Table />", () => {
+  const render = (ui: React.ReactElement): RenderResult => {
+    return baseRender(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+  };
+
+  const tables = {
+    empty_message: "Default empty message",
+    test_table_donations_empty: {
+      empty_message: "Nothing to see here",
+    },
+  };
+
+  const tablesCustom = {
+    tables: {
+      test_table_donations_empty: {
+        empty_message: "Namespaced custom message",
+      },
+    },
+  };
+
+  i18n.use(initReactI18next).init({
+    lng: "en",
+    ns: ["tables"],
+    resources: {
+      en: {
+        tables,
+        tablesCustom,
+      },
+    },
+  });
+
+  it("renders the table correctly", () => {
+    const component = render(
+      <Table
+        cellConfigs={cellConfigs}
+        name="test_table_donations"
+        records={records}
+        recordIdKey="id"
+      />
+    );
+
+    expect(component.asFragment()).toMatchSnapshot();
+  });
+
+  context("some data is null", () => {
+    it("renders the placeholder", () => {
+      const records: Donation[] = [
+        { __typename: "Donation", id: "1", status: "Good" },
+        { __typename: "Donation", id: "2", status: "Bad" },
+        { __typename: "Donation", id: "3", status: "Ugly" },
+        { __typename: "Donation", id: "4", status: null },
+      ];
+
+      const component = render(
+        <Table
+          cellConfigs={cellConfigs}
+          name="test_table_donations"
+          records={records}
+          recordIdKey="id"
+        />
+      );
+
+      const nullCell = component.getByTestId("tr-4-td-status");
+
+      expect(nullCell).toHaveTextContent("--");
+    });
+  });
+
+  context("records are empty", () => {
+    it("renders a default empty state message", () => {
+      const records: Donation[] = [];
+      const component = render(
+        <Table
+          cellConfigs={cellConfigs}
+          name="test_table_donations"
+          records={records}
+          recordIdKey="id"
+        />
+      );
+
+      expect(component.getByTestId("empty-table-state")).toHaveTextContent(
+        "Default empty message"
+      );
+    });
+
+    it("does not render the table actions", () => {
+      const records: Donation[] = [];
+      const component = render(
+        <Table
+          cellConfigs={cellConfigs}
+          name="test_table_donations"
+          records={records}
+          recordIdKey="id"
+        />
+      );
+
+      expect(component.queryByTestId("table-actions")).not.toBeInTheDocument();
+    });
+
+    context("there is a custom empty state message", () => {
+      it("renders the custom message", () => {
+        const records: Donation[] = [];
+        const component = render(
+          <Table
+            cellConfigs={cellConfigs}
+            name="test_table_donations_empty"
+            records={records}
+            recordIdKey="id"
+          />
+        );
+
+        expect(component.getByTestId("empty-table-state")).toHaveTextContent(
+          "Nothing to see here"
+        );
+      });
+    });
+
+    context("a custom tNamespace is provided", () => {
+      context("custom empty message exists", () => {
+        it("renders the custom message from the namespace", () => {
+          const records: Donation[] = [];
+          const component = render(
+            <Table
+              cellConfigs={cellConfigs}
+              name="test_table_donations_empty"
+              records={records}
+              recordIdKey="id"
+              tNamespace="tablesCustom"
+            />
+          );
+
+          expect(component.getByTestId("empty-table-state")).toHaveTextContent(
+            "Namespaced custom message"
+          );
+        });
+      });
+
+      context("custom empty message does not exist", () => {
+        it("renders the default fallback message", () => {
+          const records: Donation[] = [];
+          const component = render(
+            <Table
+              cellConfigs={cellConfigs}
+              name="test_table_no_message"
+              records={records}
+              recordIdKey="id"
+              tNamespace="tablesCustom"
+            />
+          );
+
+          expect(component.getByTestId("empty-table-state")).toHaveTextContent(
+            "Default empty message"
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/components/table/__specs__/td.spec.tsx
+++ b/packages/components/table/__specs__/td.spec.tsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+
+import { TableProvider } from "../src/table_provider";
+import { DEFAULT_TABLE_NAMESPACE } from "../src/use_table";
+import { TableCellConfig } from "../src/types";
+import { Td } from "../src/td";
+
+interface Record {
+  name?: string | null;
+  total?: number;
+}
+
+const testId = "foo-bar";
+
+interface MockTableProps {
+  children?: React.ReactNode;
+  tNamespace?: string;
+}
+
+const MockTable: React.FC<MockTableProps> = ({
+  children,
+  tNamespace = DEFAULT_TABLE_NAMESPACE,
+}): React.ReactElement => {
+  return (
+    <TableProvider value={{ name: "mockTable", tNamespace }}>
+      <table>
+        <tbody>
+          <tr>{children}</tr>
+        </tbody>
+      </table>
+    </TableProvider>
+  );
+};
+
+describe("<Td />", () => {
+  it("renders placeholder", () => {
+    const cellConfig: TableCellConfig<Record> = { dataKey: "name" };
+    const emptyRecord = { name: null };
+    const component = render(
+      <MockTable>
+        <Td cellConfig={cellConfig} record={emptyRecord} testId={testId} />
+      </MockTable>
+    );
+
+    expect(component.queryByText("--")).toBeInTheDocument();
+  });
+});

--- a/packages/components/table/__specs__/tsconfig.json
+++ b/packages/components/table/__specs__/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../tsconfig.spec.json"
+}

--- a/packages/components/table/babel.config.js
+++ b/packages/components/table/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = { presets: ["@babel/preset-env"] };

--- a/packages/components/table/clean-package.config.json
+++ b/packages/components/table/clean-package.config.json
@@ -1,0 +1,6 @@
+{
+  "replace": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts"
+  }
+}

--- a/packages/components/table/jest.config.ts
+++ b/packages/components/table/jest.config.ts
@@ -1,0 +1,3 @@
+import BaseConfig from "../../../jest.config";
+
+export default BaseConfig;

--- a/packages/components/table/jest.setup.ts
+++ b/packages/components/table/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@buoysoftware/anchor-table",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@buoysoftware/anchor-layout": "^0.20.0",
+    "@buoysoftware/anchor-typography": "^0.20.0",
+    "lodash": "^4.17.21",
+    "react-i18next": "^12.1.4"
+  },
+  "scripts": {
+    "build": "tsc -outDir dist",
+    "compile": "tsc --noEmit",
+    "postpack": "clean-package restore",
+    "prepack": "clean-package",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.3.1",
+    "ts-jest": "^29.0.4",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/packages/components/table/src/custom_style_props/table_layout.ts
+++ b/packages/components/table/src/custom_style_props/table_layout.ts
@@ -1,0 +1,10 @@
+import { style } from "styled-system";
+
+export interface TableLayoutProps {
+  tableLayout?: "auto" | "fixed";
+}
+
+export const tableLayout = style({
+  prop: "tableLayout",
+  cssProperty: "tableLayout",
+});

--- a/packages/components/table/src/empty_cell.tsx
+++ b/packages/components/table/src/empty_cell.tsx
@@ -1,0 +1,6 @@
+import { TableCellConfig } from "./types";
+
+export const EMPTY_CELL: TableCellConfig<any> = {
+  dataKey: "",
+  render: () => <></>,
+};

--- a/packages/components/table/src/empty_message.tsx
+++ b/packages/components/table/src/empty_message.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from "react-i18next";
+import { Body } from "@buoysoftware/anchor-typography";
+import { useTable, DEFAULT_TABLE_NAMESPACE } from "./use_table";
+
+export const EmptyMessage: React.FC = (): React.ReactElement => {
+  const { tNamespace, tableName } = useTable();
+  const { t } = useTranslation();
+
+  const translationLookup = [
+    `${tNamespace}:${tableName}.empty_message`,
+    `${tNamespace}:tables.${tableName}.empty_message`,
+    `${DEFAULT_TABLE_NAMESPACE}:${tableName}.empty_message`,
+    `${DEFAULT_TABLE_NAMESPACE}:empty_message`,
+  ];
+
+  return (
+    <Body mt="xl" size="m" textAlign="center" data-testid="empty-table-state">
+      {t(translationLookup)}
+    </Body>
+  );
+};

--- a/packages/components/table/src/index.ts
+++ b/packages/components/table/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./empty_cell";
+export * from "./table";

--- a/packages/components/table/src/styled_table.tsx
+++ b/packages/components/table/src/styled_table.tsx
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import { boxCss, BoxProps } from "@buoysoftware/anchor-layout";
+
+import {
+  tableLayout,
+  TableLayoutProps,
+} from "./custom_style_props/table_layout";
+
+export type TableVariant = "default" | "condensed";
+export const DEFAULT_TABLE_VARIANT: TableVariant = "default";
+
+interface OwnProps {
+  variant?: TableVariant;
+}
+
+export type StyledTableProps = OwnProps & BoxProps & TableLayoutProps;
+
+export const StyledTable = styled.table<StyledTableProps>`
+  width: 100%;
+
+  ${boxCss}
+  ${tableLayout}
+`;

--- a/packages/components/table/src/styled_tbody.tsx
+++ b/packages/components/table/src/styled_tbody.tsx
@@ -1,0 +1,35 @@
+import styled, { css } from "styled-components";
+
+interface OwnProps {
+  hasRowAction: boolean;
+}
+
+export type StyledTbodyProps = OwnProps;
+
+export const StyledTbody = styled.tbody<StyledTbodyProps>`
+  tr {
+    border-bottom: ${({ theme }) => theme.borders["1SolidSubdued"]};
+
+    ${({ hasRowAction }) =>
+      hasRowAction &&
+      css`
+        cursor: pointer;
+
+        &:hover {
+          background-color: ${({ theme }) => theme.colors.cloud};
+        }
+
+        &:focus {
+          background-color: ${({ theme }) => theme.colors.white};
+          outline: none;
+        }
+
+        &:active {
+          outline-color: ${({ theme }) => theme.colors.blue};
+          outline-offset: -3px;
+          outline-style: solid;
+          outline-width: 3px;
+        }
+      `}
+  }
+`;

--- a/packages/components/table/src/styled_thead.tsx
+++ b/packages/components/table/src/styled_thead.tsx
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+
+import { TableVariant } from "./types";
+
+interface OwnProps {
+  variant?: TableVariant;
+}
+
+export type StyledTheadProps = OwnProps;
+
+export const StyledThead = styled.thead<StyledTheadProps>`
+  border-bottom: ${({ theme }) => theme.borders["1SolidSubdued"]};
+
+  th {
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+
+    &:last-child {
+      padding-right: 0;
+    }
+  }
+
+  &:first-child th {
+    padding-top: 0;
+  }
+`;

--- a/packages/components/table/src/table.tsx
+++ b/packages/components/table/src/table.tsx
@@ -1,0 +1,53 @@
+import kebabCase from "lodash/kebabCase";
+
+import { StyledTable, StyledTableProps } from "./styled_table";
+import { Tbody } from "./tbody";
+import { Thead } from "./thead";
+import { TableProvider } from "./table_provider";
+import {
+  Connection,
+  ConnectionWithEdges,
+  PageableConnection,
+  RenderPlaceholder,
+  TbodyProps,
+} from "./types";
+import { DEFAULT_TABLE_NAMESPACE } from "./use_table";
+import { EmptyMessage } from "./empty_message";
+
+interface OwnProps<RecordData> {
+  name: string;
+  paginationData?: (Connection<RecordData> | ConnectionWithEdges<RecordData>) &
+    PageableConnection;
+  renderPlaceholder?: RenderPlaceholder<RecordData>;
+  tNamespace?: string;
+}
+
+export type TableProps<RecordData> = OwnProps<RecordData> &
+  TbodyProps<RecordData> &
+  Partial<StyledTableProps>;
+
+export const Table = <RecordData,>({
+  cellConfigs,
+  name,
+  renderPlaceholder = () => "--",
+  rowAction,
+  recordIdKey,
+  records,
+  tNamespace = DEFAULT_TABLE_NAMESPACE,
+}: TableProps<RecordData>): React.ReactElement => {
+  return (
+    <TableProvider value={{ name, tNamespace }}>
+      <StyledTable data-testid={`${kebabCase(name)}-table`}>
+        <Thead cellConfigs={cellConfigs} />
+        <Tbody
+          cellConfigs={cellConfigs}
+          records={records}
+          renderPlaceholder={renderPlaceholder}
+          rowAction={rowAction}
+          recordIdKey={recordIdKey}
+        />
+      </StyledTable>
+      {records.length === 0 && <EmptyMessage />}
+    </TableProvider>
+  );
+};

--- a/packages/components/table/src/table_provider.tsx
+++ b/packages/components/table/src/table_provider.tsx
@@ -1,0 +1,13 @@
+import { createContext } from "react";
+
+interface TableScope {
+  tNamespace?: string;
+  name: string;
+}
+
+export const TableContext = createContext<TableScope>({
+  tNamespace: "",
+  name: "",
+});
+
+export const TableProvider = TableContext.Provider;

--- a/packages/components/table/src/table_row.tsx
+++ b/packages/components/table/src/table_row.tsx
@@ -1,0 +1,36 @@
+import kebabCase from "lodash/kebabCase";
+
+import { Td } from "./td";
+import { TableRow as GeneralRowProps } from "./types";
+
+type TableRowProps<RecordData> = GeneralRowProps<RecordData>;
+
+export const TableRow = function <RecordData>({
+  cellConfigs,
+  record,
+  rowAction,
+  rowId,
+  ...tableRowProps
+}: TableRowProps<RecordData>): React.ReactElement {
+  return (
+    <tr
+      data-testid={rowId}
+      {...(rowAction ? { onClick: () => rowAction(record) } : {})}
+    >
+      {cellConfigs.map((cellConfig) => {
+        const { dataKey } = cellConfig;
+        const cellId = `${rowId}-td-${kebabCase(String(dataKey))}`;
+
+        return (
+          <Td
+            cellConfig={cellConfig}
+            key={cellId}
+            record={record}
+            testId={cellId}
+            {...tableRowProps}
+          />
+        );
+      })}
+    </tr>
+  );
+};

--- a/packages/components/table/src/tbody.tsx
+++ b/packages/components/table/src/tbody.tsx
@@ -1,0 +1,33 @@
+import get from "lodash/get";
+import { TableRow } from "./table_row";
+import { StyledTbody } from "./styled_tbody";
+import { TbodyProps as TableBodyProps } from "./types";
+
+type TbodyProps<RecordData> = Omit<TableBodyProps<RecordData>, "tableT">;
+
+export const Tbody = function <RecordData>({
+  cellConfigs,
+  records,
+  rowAction,
+  recordIdKey,
+  ...styledTbodyProps
+}: TbodyProps<RecordData>): React.ReactElement {
+  return (
+    <StyledTbody hasRowAction={!!rowAction} {...styledTbodyProps}>
+      {records.map((record) => {
+        const id = get(record, recordIdKey, undefined);
+        const rowId = `tr-${id}`;
+
+        return (
+          <TableRow
+            key={rowId}
+            record={record}
+            rowAction={rowAction}
+            rowId={rowId}
+            cellConfigs={cellConfigs}
+          />
+        );
+      })}
+    </StyledTbody>
+  );
+};

--- a/packages/components/table/src/td.tsx
+++ b/packages/components/table/src/td.tsx
@@ -1,0 +1,44 @@
+import get from "lodash/get";
+import { Body } from "@buoysoftware/anchor-typography";
+
+import { RenderPlaceholder, TableCellConfig, TableVariant } from "./types";
+
+interface TdProps<RecordData> {
+  cellConfig: TableCellConfig<RecordData>;
+  record: RecordData;
+  renderPlaceholder?: RenderPlaceholder<RecordData>;
+  testId: string;
+  variant?: TableVariant;
+}
+
+export const Td = function <RecordData>({
+  cellConfig,
+  record,
+  renderPlaceholder = () => "--",
+  testId,
+}: TdProps<RecordData>): React.ReactElement {
+  const { cellProps = () => undefined, dataKey, render } = cellConfig;
+
+  const renderCellContent = (): React.ReactNode => {
+    const value = get(record, dataKey, undefined);
+    const hasNoValue = value === null || value === undefined;
+
+    if (render) return render(record) || renderPlaceholder(record);
+    if (hasNoValue) return renderPlaceholder(record);
+
+    return value;
+  };
+
+  return (
+    <Body
+      py="s"
+      px="xs"
+      as="td"
+      data-testid={testId}
+      size="m"
+      {...cellProps(record)}
+    >
+      {renderCellContent()}
+    </Body>
+  );
+};

--- a/packages/components/table/src/thead.tsx
+++ b/packages/components/table/src/thead.tsx
@@ -1,0 +1,41 @@
+import snakeCase from "lodash/snakeCase";
+import kebabCase from "lodash/kebabCase";
+import { Heading } from "@buoysoftware/anchor-typography";
+
+import { StyledThead, StyledTheadProps } from "./styled_thead";
+import { useTable } from "./use_table";
+import { TableCellConfig } from "./types";
+
+interface OwnProps<RecordData> {
+  cellConfigs: TableCellConfig<RecordData>[];
+}
+
+type TableHeadProps<RecordData> = OwnProps<RecordData> &
+  Omit<StyledTheadProps, "theme">;
+
+export const Thead = function <RecordData>({
+  cellConfigs,
+  ...styledTheadProps
+}: TableHeadProps<RecordData>): React.ReactElement {
+  const { t } = useTable();
+
+  return (
+    <StyledThead {...styledTheadProps}>
+      <tr>
+        {cellConfigs.map(({ dataKey }, index) => {
+          return (
+            <Heading
+              size="s"
+              as="th"
+              py="s"
+              px="xs"
+              key={`th-${index}-${kebabCase(String(dataKey))}`}
+            >
+              {dataKey && t(`th.${snakeCase(String(dataKey))}`)}
+            </Heading>
+          );
+        })}
+      </tr>
+    </StyledThead>
+  );
+};

--- a/packages/components/table/src/types/index.ts
+++ b/packages/components/table/src/types/index.ts
@@ -1,0 +1,60 @@
+import type { PropertyPath } from "lodash";
+
+import { BodyProps } from "@buoysoftware/anchor-typography";
+
+export type CellProps = Partial<BodyProps> | undefined;
+
+export interface Connection<NodeData> {
+  edges: Edge<NodeData>[];
+}
+
+export interface ConnectionWithEdges<EdgeData> {
+  edges: EdgeData[];
+}
+
+export interface Edge<NodeData> {
+  node: Record<NodeData>;
+}
+
+export type Record<RecordData> = RecordData & { id?: string };
+
+export type RowAction<RecordData> = (rowData: RecordData) => void;
+
+export type TbodyProps<RecordData> = {
+  records: Record<RecordData>[];
+  recordIdKey: PropertyPath;
+} & Omit<TableRow<RecordData>, "record" | "rowId">;
+
+export type RenderPlaceholder<RecordData> = (
+  rowData: RecordData
+) => React.ReactElement | string;
+
+export interface TableCellConfig<RecordData> {
+  cellProps?: (rowData: RecordData) => CellProps;
+  dataKey: PropertyPath;
+  name?: string;
+  render?: (rowData: RecordData) => React.ReactNode;
+}
+
+export interface TableRow<RecordData> {
+  cellConfigs: TableCellConfig<RecordData>[];
+  record: Record<RecordData>;
+  renderPlaceholder?: RenderPlaceholder<RecordData>;
+  rowAction?: RowAction<RecordData>;
+  rowId: string;
+}
+
+export interface PageInfo {
+  startCursor: string | null;
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  perPage: number;
+}
+
+export interface PageableConnection {
+  pageInfo: PageInfo;
+  totalCount: number;
+}
+
+export type TableVariant = "default" | "condensed";

--- a/packages/components/table/src/use_table.ts
+++ b/packages/components/table/src/use_table.ts
@@ -1,0 +1,26 @@
+import { useContext } from "react";
+import { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+import { TableContext } from "./table_provider";
+
+export const DEFAULT_TABLE_NAMESPACE = "tables";
+
+interface UseTable {
+  t: TFunction;
+  tableName: string;
+  tNamespace: string;
+}
+
+export const useTable = (): UseTable => {
+  const { name, tNamespace = DEFAULT_TABLE_NAMESPACE } =
+    useContext(TableContext);
+  const keyPrefix =
+    tNamespace === DEFAULT_TABLE_NAMESPACE ? name : `tables.${name}`;
+  const { t } = useTranslation(tNamespace, { keyPrefix });
+
+  return {
+    t,
+    tableName: name,
+    tNamespace,
+  };
+};

--- a/packages/components/table/stories/table.stories.mdx
+++ b/packages/components/table/stories/table.stories.mdx
@@ -1,0 +1,101 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import { Canvas, Story } from "@storybook/addon-docs";
+
+import { Table } from "../src";
+
+<Meta
+  title="Components / Table"
+  component={Table}
+  parameters={{
+    controls: {
+      include: ["records"]
+    }
+  }}
+/>
+
+
+export const Template = ({ cellProps = () => ({}), ...args }) => {
+  i18n.use(initReactI18next).init({
+    lng: "en",
+    ns: ["tables"],
+    resources: {
+      en: {
+        tables: {
+          donors: {
+            empty_message: "No donors to display",
+            th: {
+              name: "Donor Name",
+              id: "Donor ID",
+              deferred: "Deferred",
+              my_facility_name: "Assigned Center",
+              level: "Level"
+            },
+          }
+        }
+      },
+    },
+  });
+  const CELL_CONFIGS = [
+    { dataKey: "name" },
+    { dataKey: "id" },
+    { dataKey: "myFacility.name" },
+    { dataKey: "level" },
+  ].map((cellConfig) => ({ ...cellConfig, cellProps }))
+  return (
+    <Table
+      cellConfigs={CELL_CONFIGS}
+      name="donors"
+      recordIdKey="id"
+      {...args}
+    />
+  )
+};
+
+## Basic Usage
+
+<Canvas>
+  <Story
+    args={{
+      records: [
+        { name: "Jerry Seinfeld", id: 1, myFacility: { name: "Paris " }, level: 1 },
+        { name: "Cosmo Kramer", id: 2, myFacility: { name: "Paris " }, level: 7 },
+        { name: "Elaine Benes", id: 3, myFacility: { name: "Paris " }, level: 4 },
+        { name: "George Costanza", id: 4, myFacility: { name: "Paris " }, level: 0 },
+      ]
+    }}
+    name="Table with data"
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Empty Table
+
+<Canvas>
+  <Story
+    args={{ records: [] }}
+    name="Empty Table"
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Row styling
+
+<Canvas>
+  <Story
+    args={{
+      cellProps: ({ level }) => ( level == 0 ? { background: "red", color: "white", } : {} ),
+      records: [
+        { name: "Jerry Seinfeld", id: 1, myFacility: { name: "Paris " }, level: 1 },
+        { name: "Cosmo Kramer", id: 2, myFacility: { name: "Paris " }, level: 7 },
+        { name: "Elaine Benes", id: 3, myFacility: { name: "Paris " }, level: 4 },
+        { name: "George Costanza", id: 4, myFacility: { name: "Paris " }, level: 0 },
+      ]
+    }}
+    name="Row styling"
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/components/table/tsconfig.json
+++ b/packages/components/table/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src", "index.ts", "../../../@types"]
+}


### PR DESCRIPTION
This is a partial port of the TableBuilder out of Wharf / Buoy to anchor-ui.

Main changes:

* Remove the orientation variant. We only use it in one place within our codebases
* Remove condensed vs default as we don't have styles in the design system yet for these 2 variants.
* Does not include `ConnectionTable` or `TableActions` yet. This will be introduced separately as `TableActions` requires the introduction of the text button component.

<img width="1547" alt="image" src="https://user-images.githubusercontent.com/105694/215153132-40acd10d-c759-477a-a75f-caaadfecd8bd.png">
