### PR TITLE
Refactor DropdownMenu to support custom trigger

### DIFF
--- a/packages/components/dropdown_menu/src/dropdown_menu.tsx
+++ b/packages/components/dropdown_menu/src/dropdown_menu.tsx
@@ -1,8 +1,12 @@
 import kebabCase from "lodash/kebabCase";
 import { Button } from "@buoysoftware/anchor-button";
 import { ChevronDown } from "@styled-icons/feather";
-import { Popover, PopoverProps } from "react-tiny-popover";
 import { useState } from "react";
+
+import {
+  DropdownMenuPopover,
+  DropdownMenuPopoverProps,
+} from "./dropdown_menu_popover";
 
 interface OwnProps {
   children: React.ReactNode;
@@ -10,9 +14,8 @@ interface OwnProps {
   label: string;
 }
 
-type DropdownMenuProps = OwnProps & Partial<Omit<PopoverProps, "children">>;
-
-const MENU_CONTAINER_OFFSET = 3;
+type DropdownMenuProps = OwnProps &
+  Partial<Omit<DropdownMenuPopoverProps, "children">>;
 
 export const DropdownMenu: React.FC<DropdownMenuProps> = ({
   children,
@@ -30,25 +33,21 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
   };
 
   return (
-    <Popover
-      align="start"
-      padding={MENU_CONTAINER_OFFSET}
-      isOpen={isOpen}
-      containerStyle={{ zIndex: "3" }}
-      content={<>{children}</>}
-      onClickOutside={() => setIsOpen(false)}
-      positions={["bottom", "top", "left", "right"]}
+    <DropdownMenuPopover
+      trigger={
+        <Button
+          data-testid={id}
+          icon={<ChevronDown size="20px" strokeWidth="2px" />}
+          iconPosition="right"
+          onClick={onClick}
+          size="l"
+        >
+          {label}
+        </Button>
+      }
       {...popoverProps}
     >
-      <Button
-        data-testid={id}
-        icon={<ChevronDown size="20px" strokeWidth="2px" />}
-        iconPosition="right"
-        onClick={onClick}
-        size="l"
-      >
-        {label}
-      </Button>
-    </Popover>
+      {children}
+    </DropdownMenuPopover>
   );
 };

--- a/packages/components/dropdown_menu/src/dropdown_menu_popover.tsx
+++ b/packages/components/dropdown_menu/src/dropdown_menu_popover.tsx
@@ -1,0 +1,44 @@
+import { Popover, PopoverProps } from "react-tiny-popover";
+import { useState, cloneElement } from "react";
+
+interface OwnProps {
+  children: React.ReactNode;
+  trigger: React.ReactElement;
+}
+
+export type DropdownMenuPopoverProps = OwnProps &
+  Partial<Omit<PopoverProps, "children">>;
+
+const MENU_CONTAINER_OFFSET = 3;
+
+export const DropdownMenuPopover: React.FC<DropdownMenuPopoverProps> = ({
+  children,
+  trigger,
+  ...popoverProps
+}): React.ReactElement => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onClick = (e: React.MouseEvent): void => {
+    e.preventDefault();
+    setIsOpen(!isOpen);
+  };
+
+  const triggerWithHandler = cloneElement(trigger, {
+    onClick,
+  });
+
+  return (
+    <Popover
+      align="start"
+      padding={MENU_CONTAINER_OFFSET}
+      isOpen={isOpen}
+      containerStyle={{ zIndex: "3" }}
+      content={<>{children}</>}
+      onClickOutside={() => setIsOpen(false)}
+      positions={["bottom", "top", "left", "right"]}
+      {...popoverProps}
+    >
+      {triggerWithHandler}
+    </Popover>
+  );
+};

--- a/packages/components/dropdown_menu/src/index.ts
+++ b/packages/components/dropdown_menu/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./dropdown_menu";
-export * from "./dropdown_menu_list";
 export * from "./dropdown_menu_item";
+export * from "./dropdown_menu_list";
+export * from "./dropdown_menu_popover";

--- a/packages/components/dropdown_menu/stories/dropdown_menu.stories.mdx
+++ b/packages/components/dropdown_menu/stories/dropdown_menu.stories.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Story } from "@storybook/addon-docs";
-import { DropdownMenu, DropdownMenuList, DropdownMenuItem } from "../src";
+import { Button } from "@buoysoftware/anchor-button";
+import { DropdownMenu, DropdownMenuList, DropdownMenuItem, DropdownMenuPopover } from "../src";
 
 <Meta
   title="Components / Dropdown Menu"
@@ -40,5 +41,21 @@ import {
     args={{ label: "Actions" }}
   >
     {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Custom trigger
+
+<Canvas>
+  <Story name="Dropdown with custom trigger">
+    <DropdownMenuPopover
+      trigger={<Button colorScheme="primary">Actions</Button>}>
+      <DropdownMenuList>
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+        <DropdownMenuItem>Item 2</DropdownMenuItem>
+        <DropdownMenuItem>Item 3</DropdownMenuItem>
+        <DropdownMenuItem>Item 4</DropdownMenuItem>
+      </DropdownMenuList>
+    </DropdownMenuPopover>
   </Story>
 </Canvas>


### PR DESCRIPTION
Break apart the DropdownMenu exposing the Popover component so that you can utilize your own custom trigger such as in the sidenav application menu.

<img width="1473" alt="image" src="https://user-images.githubusercontent.com/105694/215172356-7d8e618e-fdf8-4623-9386-d5c7303ced42.png">
