### PR TITLE
Handle empty breadcrumb

### DIFF
--- a/packages/components/breadcrumbs/src/styled_breadcrumbs.tsx
+++ b/packages/components/breadcrumbs/src/styled_breadcrumbs.tsx
@@ -5,7 +5,7 @@ export const StyledBreadcrumbs = styled(Flex).attrs(() => ({
   as: "nav",
   listStyle: "none",
 }))<FlexProps>`
-  .breadcrumb:not(:last-child):after {
+  .breadcrumb:not(:first-child):not(:empty):before {
     color: ${(props) => props.theme.colors.text.secondary};
     content: "/";
     font-size: ${(props) => props.theme.fontSizes["font-size-75"]};

--- a/packages/components/breadcrumbs/stories/breadcrumbs.stories.mdx
+++ b/packages/components/breadcrumbs/stories/breadcrumbs.stories.mdx
@@ -16,6 +16,7 @@ export const Template = (args) => {
       <Breadcrumb>Donors</Breadcrumb>
       <Breadcrumb>Donor 123</Breadcrumb>
       <Breadcrumb>Edit</Breadcrumb>
+      <Breadcrumb></Breadcrumb>
     </Breadcrumbs>
   );
 }


### PR DESCRIPTION
If a breadcrumb is empty for some reason, don't render the / before it.

This moves the `after` psuedo class to a `before` so that we can check if the node is empty before rendering the content.