### PR TITLE
Introduce LegacyPageFooter

### DIFF
--- a/packages/anchor-ui-compat/package.json
+++ b/packages/anchor-ui-compat/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@buoysoftware/anchor-ui-legacy-button": "^0.30.3",
     "@buoysoftware/anchor-ui-legacy-layout": "^0.30.3",
+    "@buoysoftware/anchor-ui-legacy-page-footer": "^0.30.0",
     "@buoysoftware/anchor-ui-legacy-text": "^0.30.0"
   }
 }

--- a/packages/anchor-ui-compat/src/index.ts
+++ b/packages/anchor-ui-compat/src/index.ts
@@ -1,3 +1,4 @@
 export * from "@buoysoftware/anchor-ui-legacy-button";
 export * from "@buoysoftware/anchor-ui-legacy-layout";
+export * from "@buoysoftware/anchor-ui-legacy-page-footer";
 export * from "@buoysoftware/anchor-ui-legacy-text";

--- a/packages/components/legacy_page_footer/clean-package.config.json
+++ b/packages/components/legacy_page_footer/clean-package.config.json
@@ -1,0 +1,6 @@
+{
+  "replace": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts"
+  }
+}

--- a/packages/components/legacy_page_footer/package.json
+++ b/packages/components/legacy_page_footer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@buoysoftware/anchor-ui-legacy-page-footer",
+  "version": "0.30.0",
+  "main": "src/index.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@buoysoftware/anchor-layout": "^0.30.0"
+  },
+  "scripts": {
+    "build": "tsc -outDir dist",
+    "compile": "tsc --noEmit",
+    "postpack": "clean-package restore",
+    "prepack": "clean-package"
+  }
+}

--- a/packages/components/legacy_page_footer/src/index.ts
+++ b/packages/components/legacy_page_footer/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./legacy_page_footer";

--- a/packages/components/legacy_page_footer/src/legacy_page_footer.tsx
+++ b/packages/components/legacy_page_footer/src/legacy_page_footer.tsx
@@ -1,0 +1,32 @@
+import { Box } from "@buoysoftware/anchor-layout";
+
+interface OwnProps {
+  children?: React.ReactNode;
+}
+
+export const LegacyPageFooter: React.FC<OwnProps> = ({
+  children,
+}): React.ReactElement => {
+  return (
+    <Box
+      bg="white"
+      borderTop="1SolidSubdued"
+      bottom={0}
+      height="pageFooter"
+      left={0}
+      position="fixed"
+      px="xxxl"
+      right={0}
+      zIndex={2}
+    >
+      <Box
+        alignItems="center"
+        display="flex"
+        height="100%"
+        justifyContent="flex-end"
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+};

--- a/packages/components/legacy_page_footer/stories/legacy_page_footer.stories.mdx
+++ b/packages/components/legacy_page_footer/stories/legacy_page_footer.stories.mdx
@@ -24,10 +24,12 @@ export const Template = (args) => {
 
 # LegacyPageFooter
 
-The LegacyPageFooter component renders a footer that will stick to the bottom of the
-screen regardless of the height the content on the screen. The content of the
-footer is right-aligned, as this component is usually used for keeping action buttons at
-the bottom of the screen.
+The LegacyPageFooter component provides a compatibility bridge to migrate
+existing applications to use AnchorUI incrementally. All legacy theme values and
+abstract components have been replaced with their AnchorUI counterparts.
+
+This component renders a footer that will stick to the bottom of the screen
+regardless of the height the content on the screen.
 
 ## Import
 

--- a/packages/components/legacy_page_footer/stories/legacy_page_footer.stories.mdx
+++ b/packages/components/legacy_page_footer/stories/legacy_page_footer.stories.mdx
@@ -1,0 +1,53 @@
+import { Canvas, Story } from "@storybook/addon-docs";
+
+import { LegacyPageFooter } from "../src";
+
+<Meta
+  title="anchor-ui-compat / LegacyPageFooter"
+  component={LegacyPageFooter}
+  decorators={[
+    (Story) => (
+      <div style={{ background: "orange", border: "1px solid black", height:
+"200px", padding: "20px 20px", transform: "translate(0, 0)" }}>
+        Decorator content
+        {Story()}
+      </div>
+    ),
+  ]}
+/>
+
+export const Template = (args) => {
+  return (
+    <LegacyPageFooter {...args}>LegacyPageFooter content</LegacyPageFooter>
+  );
+}
+
+# LegacyPageFooter
+
+The LegacyPageFooter component renders a footer that will stick to the bottom of the
+screen regardless of the height the content on the screen. The content of the
+footer is right-aligned, as this component is usually used for keeping action buttons at
+the bottom of the screen.
+
+## Import
+
+```javascript
+import { LegacyPageFooter } from "@buoysoftware/anchor-ui-compat";
+```
+
+## Basic Usage
+
+<Canvas>
+  <Story
+    name="LegacyPageFooter"
+    parameters={{
+      docs: {
+        source: {
+          excludeDecorators: true,
+        },
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/components/legacy_page_footer/tsconfig.json
+++ b/packages/components/legacy_page_footer/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src", "index.ts", "../../../@types"]
+}


### PR DESCRIPTION
This component will replace StickyFooter, which is used widely across BuoyRails as the footer for the Donor flow, usually containing buttons for save/continue/cancel. As we already have a new PageTemplate component, this will be a compatibility bridge to leverage the new theme until such time as we refactor to using the new PageTemplate.

<details><summary>Screenshot</summary>

<img width="1623" alt="Screenshot 2023-02-23 at 5 23 01 PM" src="https://user-images.githubusercontent.com/3165407/221044603-ce970b42-9492-4c37-a391-89a7aec541b0.png">
</details>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204025889370510