### PR TITLE
Let Thursdays be dependabot days (#260)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: thursday
+      time: "13:00"
     open-pull-requests-limit: 99
     ignore:
       - dependency-name: "@types/react"


### PR DESCRIPTION
That way we don't need to take care of patch and minor releases every day. We'll still get instant security updates from Dependabot, regardless of schedule.

See also:

- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates
- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates