### PR TITLE
Adding TypographyProps to LegacyText

### DIFF
--- a/packages/components/legacy_text/src/legacy_text.tsx
+++ b/packages/components/legacy_text/src/legacy_text.tsx
@@ -1,5 +1,6 @@
 import { BoxProps } from "@buoysoftware/anchor-layout";
 import { Body, Heading, Subheading } from "@buoysoftware/anchor-typography";
+import { TypographyProps } from "styled-system";
 
 export type LegacyTextVariant =
   | "bodyLargeBold"
@@ -23,7 +24,7 @@ interface OwnProps {
   variant?: LegacyTextVariant;
 }
 
-export type TextProps = BoxProps & OwnProps;
+export type TextProps = BoxProps & TypographyProps & OwnProps;
 
 export const LegacyText: React.FC<TextProps> = ({
   children,


### PR DESCRIPTION
While incorporating the LegacyText component, it was discovered that the fontSize prop could not be set on the component itself. In order to make the LegacyText component almost completely plug-and-play with repo-specific components, this PR adds the TypographyProps to LegacyText.