### PR TITLE
Add button props to LegacyButton

### DIFF
--- a/packages/components/legacy_button/src/legacy_button.tsx
+++ b/packages/components/legacy_button/src/legacy_button.tsx
@@ -30,7 +30,7 @@ interface OwnProps {
   sizeVariant?: LegacyButtonSize;
 }
 
-export type ButtonProps = OwnProps & Omit<BoxProps, "size" | "color">;
+export type ButtonProps = OwnProps & Omit<BoxProps, "size" | "color"> & React.ButtonHTMLAttributes<HTMLButtonElement>;;
 
 export const LegacyButton: React.FC<ButtonProps> = ({
   variant,


### PR DESCRIPTION
TypeScript compilation fails when `LegacyButton` receives a valid button prop (i.e. `onClick`). This adds the proper typing to the legacy component to accept these props