### PR TITLE
Let TextField receive BoxProps / Text and Select Fields hints (aka helper text)

### DIFF
--- a/packages/components/form/__specs__/__snapshots__/select_field.spec.tsx.snap
+++ b/packages/components/form/__specs__/__snapshots__/select_field.spec.tsx.snap
@@ -35,11 +35,29 @@ exports[`<SelectField /> async is false renders properly 1`] = `
   z-index: 1;
 }
 
+.c5 {
+  box-sizing: border-box;
+  color: #62666A;
+  width: s;
+  height: s;
+  margin-top: 0.25rem;
+}
+
 .c3 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI, Roboto,Helvetica Neue,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 600;
+}
+
+.c6 {
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI, Roboto,Helvetica Neue,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-style: none;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1rem;
 }
 
 <form
@@ -145,6 +163,15 @@ exports[`<SelectField /> async is false renders properly 1`] = `
           />
         </div>
       </div>
+      <p
+        class="c5 c6"
+        color="text.secondary"
+        font-size="font-size-75"
+        font-style="none"
+        font-weight="400"
+      >
+        Optional helper text
+      </p>
     </div>
     <button
       type="submit"
@@ -190,11 +217,29 @@ exports[`<SelectField /> async is true renders properly 1`] = `
   z-index: 1;
 }
 
+.c5 {
+  box-sizing: border-box;
+  color: #62666A;
+  width: s;
+  height: s;
+  margin-top: 0.25rem;
+}
+
 .c3 {
   font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI, Roboto,Helvetica Neue,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 600;
+}
+
+.c6 {
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI, Roboto,Helvetica Neue,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-style: none;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1rem;
 }
 
 <form
@@ -300,6 +345,15 @@ exports[`<SelectField /> async is true renders properly 1`] = `
           />
         </div>
       </div>
+      <p
+        class="c5 c6"
+        color="text.secondary"
+        font-size="font-size-75"
+        font-style="none"
+        font-weight="400"
+      >
+        Optional helper text
+      </p>
     </div>
     <button
       type="submit"

--- a/packages/components/form/__specs__/__snapshots__/text_field.spec.tsx.snap
+++ b/packages/components/form/__specs__/__snapshots__/text_field.spec.tsx.snap
@@ -1,0 +1,225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TextField /> renders properly 1`] = `
+<DocumentFragment>
+  .c0 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  box-sizing: border-box;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 300px;
+  margin-bottom: 1.5rem;
+}
+
+.c2 {
+  box-sizing: border-box;
+  color: #101112;
+  width: s;
+  height: s;
+  margin-bottom: 0.25rem;
+}
+
+.c4 {
+  box-sizing: border-box;
+  position: relative;
+  z-index: 1;
+}
+
+.c6 {
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c8 {
+  box-sizing: border-box;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c10 {
+  box-sizing: border-box;
+  color: #62666A;
+  width: s;
+  height: s;
+  margin-top: 0.25rem;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c3 {
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI, Roboto,Helvetica Neue,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 600;
+}
+
+.c11 {
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI, Roboto,Helvetica Neue,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-style: none;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1rem;
+}
+
+.c9 {
+  outline: none;
+  background: none;
+  border: none;
+  color: inherit;
+  fontsize: inherit;
+  line-height: inherit;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  text-align: inherit;
+  box-sizing: border-box;
+}
+
+.c5 {
+  font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI, Roboto,Helvetica Neue,sans-serif;
+  display: inline-block;
+  background-color: #FFFFFF;
+  border: 1px solid;
+  border-radius: 4px;
+  color: #101112;
+  font-size: 0.875rem;
+  height: 40px;
+  line-height: 1rem;
+  margin: 0;
+  padding: 0.75rem 0.75rem;
+  width: 300px;
+}
+
+.c5 transition:"background 0.75s ease",
+.c5 input::-webkit-input-placeholder {
+  opacity: 1;
+  color: #9CA1A5;
+  -webkit-text-fill-color: $({ theme}) => theme.colors.text.tertiary;
+}
+
+.c5 transition:"background 0.75s ease",
+.c5 input::-moz-placeholder {
+  opacity: 1;
+  color: #9CA1A5;
+  -webkit-text-fill-color: $({ theme}) => theme.colors.text.tertiary;
+}
+
+.c5 transition:"background 0.75s ease",
+.c5 input:-ms-input-placeholder {
+  opacity: 1;
+  color: #9CA1A5;
+  -webkit-text-fill-color: $({ theme}) => theme.colors.text.tertiary;
+}
+
+.c5 transition:"background 0.75s ease",
+.c5 input::placeholder {
+  opacity: 1;
+  color: #9CA1A5;
+  -webkit-text-fill-color: $({ theme}) => theme.colors.text.tertiary;
+}
+
+.c5:hover {
+  border-color: #46494D;
+}
+
+<form
+    autocomplete="off"
+    class="c0"
+    data-testid="test-form"
+    id="test-form"
+  >
+    <div
+      class="c1 "
+      data-testid="form-field-my-text-field"
+      display="flex"
+      width="input"
+    >
+      <label
+        class="c2 c3"
+        color="text.primary"
+        font-weight="600"
+        for="my-text-field"
+      >
+        This is my text field
+      </label>
+      <div
+        class="c4"
+      >
+        <div
+          class="c0 c5"
+          data-testid="input-wrapper-text-field-test"
+        >
+          <div
+            class="c6 c7"
+            display="flex"
+          >
+            <div
+              class="c8"
+            >
+              <input
+                aria-invalid="false"
+                class="c9"
+                data-testid="input-text-field-test"
+                id="my-text-field"
+                name="myTextField"
+                placeholder="Enter value"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <p
+        class="c10 c11"
+        color="text.secondary"
+        font-size="font-size-75"
+        font-style="none"
+        font-weight="400"
+      >
+        Optional helper text
+      </p>
+    </div>
+    <button
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;

--- a/packages/components/form/__specs__/select_field.spec.tsx
+++ b/packages/components/form/__specs__/select_field.spec.tsx
@@ -2,7 +2,12 @@ import { useForm } from "react-hook-form";
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
-import { render as baseRender, UserRenderResult } from "../test_utils";
+import {
+  act,
+  render as baseRender,
+  waitFor,
+  UserRenderResult,
+} from "../test_utils";
 import { Form, SelectField } from "../src";
 
 describe("<SelectField />", () => {
@@ -23,6 +28,11 @@ describe("<SelectField />", () => {
         select: {
           required: "This field is required",
         },
+      },
+    },
+    hints: {
+      test_form: {
+        my_select_field: "Optional helper text",
       },
     },
     labels: {
@@ -88,9 +98,13 @@ describe("<SelectField />", () => {
         it("flags the field as invalid", async () => {
           const { user, getByLabelText, getByText } = render({ async });
 
-          await user.click(getByText("Submit"));
+          await act(() => {
+            user.click(getByText("Submit"));
+          });
 
-          expect(getByLabelText(FIELD_LABEL)).toBeInvalid();
+          await waitFor(() => {
+            expect(getByLabelText(FIELD_LABEL)).toBeInvalid();
+          });
         });
 
         it("displays errors associated with the field", async () => {
@@ -99,9 +113,15 @@ describe("<SelectField />", () => {
             "forms:errors.input_types.select.required"
           );
 
-          await user.click(getByText("Submit"));
+          await act(() => {
+            user.click(getByText("Submit"));
+          });
 
-          expect(getByLabelText(FIELD_LABEL)).toHaveErrorMessage(errorMessage);
+          await waitFor(() => {
+            expect(getByLabelText(FIELD_LABEL)).toHaveErrorMessage(
+              errorMessage
+            );
+          });
         });
       });
     });

--- a/packages/components/form/__specs__/text_field.spec.tsx
+++ b/packages/components/form/__specs__/text_field.spec.tsx
@@ -1,0 +1,103 @@
+import { useForm } from "react-hook-form";
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import {
+  act,
+  render as baseRender,
+  waitFor,
+  UserRenderResult,
+} from "../test_utils";
+import { Form, TextField } from "../src";
+
+describe("<TextField />", () => {
+  const translations = {
+    errors: {
+      required: "This field is required",
+    },
+    hints: {
+      test_form: {
+        my_text_field: "Optional helper text",
+      },
+    },
+    labels: {
+      my_text_field: "This is my text field",
+    },
+    placeholders: {
+      test_form: {
+        my_text_field: "Enter value",
+      },
+    },
+  };
+
+  i18n.use(initReactI18next).init({
+    lng: "en",
+    ns: ["forms"],
+    resources: {
+      en: {
+        forms: translations,
+      },
+    },
+  });
+
+  const MockForm: React.FC = (): React.ReactElement => {
+    const form = useForm();
+
+    return (
+      <Form
+        id="test-form"
+        data-testid="test-form"
+        form={form}
+        scope="test_form"
+        onSubmit={jest.fn()}
+      >
+        <TextField
+          data-testid="text-field-test"
+          rules={{ required: true }}
+          name="myTextField"
+        />
+        <button type="submit">Submit</button>
+      </Form>
+    );
+  };
+
+  function render(): UserRenderResult {
+    return baseRender(<MockForm />);
+  }
+
+  const FIELD_LABEL = i18n.t("forms:labels.my_text_field");
+
+  it("renders properly", () => {
+    const form = render();
+
+    expect(form.asFragment()).toMatchSnapshot();
+  });
+
+  context("with an error", () => {
+    it("displays errors associated with the field", async () => {
+      const { user, getByLabelText, getByText } = render();
+      const errorMessage = i18n.t("forms:errors.required");
+
+      await act(() => {
+        user.click(getByText("Submit"));
+      });
+
+      await waitFor(() => {
+        expect(getByLabelText(FIELD_LABEL)).toHaveErrorMessage(errorMessage);
+      });
+    });
+  });
+
+  context("with a hint", () => {
+    it("displays the hint associated with the field", async () => {
+      const { user, getByText } = render();
+      const hint = i18n.t("forms:hints.test_form.my_text_field");
+
+      await act(() => {
+        user.click(getByText("Submit"));
+      });
+
+      expect(getByText(hint)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/components/form/__specs__/use_form_field.spec.tsx
+++ b/packages/components/form/__specs__/use_form_field.spec.tsx
@@ -175,6 +175,68 @@ describe("useFormField", () => {
     });
   });
 
+  describe("hint", () => {
+    context("hint for field does not exist", () => {
+      it("returns undefined", () => {
+        const { result } = renderFieldHook({ name: "testField" });
+
+        expect(result.current.hint).toBe(undefined);
+      });
+    });
+
+    context("default namespace provides a hint", () => {
+      it("renders the default namespace hint for the field", () => {
+        const mockTranslations = {
+          forms: {
+            hints: {
+              test_form: {
+                test_field: "Default namespace helper text",
+              },
+            },
+          },
+        };
+
+        const { result } = renderFieldHook({
+          name: "testField",
+          mockTranslations,
+        });
+
+        expect(result.current.hint).toEqual("Default namespace helper text")
+      });
+    });
+
+    context("custom namespace provides a hint", () => {
+      it("renders the custom namespace hint for the field", () => {
+        const mockTranslations = {
+          forms: {
+            hints: {
+              test_form: {
+                test_field: "Default namespace helper text",
+              },
+            },
+          },
+          providedNamespace: {
+            forms: {
+              hints: {
+                test_form: {
+                  test_field: "Provided namespace helper text",
+                },
+              },
+            },
+          },
+        };
+
+        const { result } = renderFieldHook({
+          name: "testField",
+          mockTranslations,
+          tNamespace: ["providedNamespace"],
+        });
+
+        expect(result.current.hint).toEqual("Provided namespace helper text")
+      });
+    });
+  });
+
   describe("inputId", () => {
     it("generates an id from the field name", () => {
       const { result } = renderFieldHook({ name: "testField" });

--- a/packages/components/form/src/form_field.tsx
+++ b/packages/components/form/src/form_field.tsx
@@ -2,6 +2,7 @@ import kebabCase from "lodash/kebabCase";
 import styled from "styled-components";
 import { FieldError as HookFormFieldError } from "react-hook-form";
 import { Box, BoxProps } from "@buoysoftware/anchor-layout";
+import { Body } from "@buoysoftware/anchor-typography";
 import { Label } from "./label";
 
 import { FieldError, InputType } from "./field_error";
@@ -9,6 +10,7 @@ import { FieldError, InputType } from "./field_error";
 interface OwnProps {
   children: React.ReactNode;
   error?: HookFormFieldError;
+  hint?: string;
   inputId: string;
   inputType?: InputType;
   label: string;
@@ -18,7 +20,16 @@ interface OwnProps {
 export type FormFieldProps = OwnProps & Omit<BoxProps, "errors">;
 
 export const FormField = styled(
-  ({ children, error, inputId, inputType, name, label, ...elementProps }) => {
+  ({
+    children,
+    error,
+    hint,
+    inputId,
+    inputType,
+    name,
+    label,
+    ...elementProps
+  }) => {
     const testId = kebabCase(inputId);
 
     return (
@@ -36,13 +47,18 @@ export const FormField = styled(
         <Box position="relative" zIndex={1}>
           {children}
         </Box>
+        {hint && (
+          <Body mt="xxs" size="s" color="text.secondary">
+            {hint}
+          </Body>
+        )}
         <FieldError
           error={error}
           inputId={inputId}
           inputType={inputType}
           mt="xxs"
-          width="input"
           name={name}
+          width="input"
         />
       </Box>
     );

--- a/packages/components/form/src/form_field.tsx
+++ b/packages/components/form/src/form_field.tsx
@@ -41,6 +41,7 @@ export const FormField = styled(
           inputId={inputId}
           inputType={inputType}
           mt="xxs"
+          width="input"
           name={name}
         />
       </Box>

--- a/packages/components/form/src/select_field.tsx
+++ b/packages/components/form/src/select_field.tsx
@@ -47,6 +47,7 @@ export const SelectField = function <
   const { t } = useTranslation(["anchorForms", "forms"]);
   const {
     error,
+    hint,
     inputId,
     label: formFieldLabel,
     placeholder,
@@ -62,13 +63,14 @@ export const SelectField = function <
     <FormField
       data-testid={`select-field-${inputId}`}
       error={error}
+      hint={hint}
       inputId={inputId}
       inputType="select"
       label={label}
       name={name}
       position="relative"
-      zIndex={zIndex}
       width={width}
+      zIndex={zIndex}
     >
       {banner && <Box my="xxs">{banner}</Box>}
       <Controller

--- a/packages/components/form/src/text_field.tsx
+++ b/packages/components/form/src/text_field.tsx
@@ -28,6 +28,7 @@ export const TextField: React.FC<TextFieldProps> = ({
   const wrapperProps = pick(inputProps, STYLED_INPUT_WRAPPER_PROP_LIST);
   const {
     error,
+    hint,
     inputId,
     label: formFieldLabel,
     placeholder,
@@ -39,6 +40,7 @@ export const TextField: React.FC<TextFieldProps> = ({
     <FormField
       error={error}
       label={fieldLabel}
+      hint={hint}
       inputId={inputId}
       name={name}
       {...wrapperProps}

--- a/packages/components/form/src/text_field.tsx
+++ b/packages/components/form/src/text_field.tsx
@@ -1,7 +1,11 @@
 import { useFormContext, RegisterOptions } from "react-hook-form";
-import { Box } from "@buoysoftware/anchor-layout";
+import { BoxProps } from "@buoysoftware/anchor-layout";
+import pick from "lodash/pick";
 
 import { Input, InputProps } from "./input";
+import {
+  STYLED_INPUT_WRAPPER_PROP_LIST
+} from "./input/styled_input_wrapper_prop_list";
 import { FormField } from "./form_field";
 import { useFormField } from "./use_form_field";
 
@@ -12,7 +16,7 @@ interface OwnProps {
   rules?: RegisterOptions;
 }
 
-export type TextFieldProps = OwnProps & Omit<InputProps, "theme">;
+export type TextFieldProps = OwnProps & Omit<InputProps, "theme"> & BoxProps;
 
 export const TextField: React.FC<TextFieldProps> = ({
   Component = Input,
@@ -21,6 +25,7 @@ export const TextField: React.FC<TextFieldProps> = ({
   rules,
   ...inputProps
 }): React.ReactElement => {
+  const wrapperProps = pick(inputProps, STYLED_INPUT_WRAPPER_PROP_LIST);
   const {
     error,
     inputId,
@@ -31,16 +36,20 @@ export const TextField: React.FC<TextFieldProps> = ({
   const fieldLabel = label ?? formFieldLabel;
 
   return (
-    <Box>
-      <FormField error={error} label={fieldLabel} inputId={inputId} name={name}>
-        <Component
-          error={!!error}
-          id={inputId}
-          placeholder={placeholder}
-          {...register(name, { shouldUnregister: true, ...rules })}
-          {...inputProps}
-        />
-      </FormField>
-    </Box>
+    <FormField
+      error={error}
+      label={fieldLabel}
+      inputId={inputId}
+      name={name}
+      {...wrapperProps}
+    >
+      <Component
+        error={!!error}
+        id={inputId}
+        placeholder={placeholder}
+        {...register(name, { shouldUnregister: true, ...rules })}
+        {...inputProps}
+      />
+    </FormField>
   );
 };

--- a/packages/components/form/src/use_form_field.ts
+++ b/packages/components/form/src/use_form_field.ts
@@ -15,6 +15,7 @@ export interface UseFormFieldProps<L extends true | false> {
 
 interface FormField<L> {
   error: FieldError;
+  hint?: string;
   inputId: string;
   label: L extends true ? string : undefined;
   placeholder: string;
@@ -52,10 +53,21 @@ export const useFormField = <L extends true | false>({
       ])
     : undefined;
 
+  const hint = t(
+    [
+      `forms.hints.${snakeScope}.${i18nKey}`,
+      `hints.${snakeScope}.${i18nKey}`,
+    ],
+    {
+      defaultValue: "",
+    }
+  );
+
   const error = get(errors, name);
 
   return {
     error,
+    hint: hint ? hint : undefined,
     inputId,
     label,
     placeholder,

--- a/packages/components/form/stories/select_field.stories.mdx
+++ b/packages/components/form/stories/select_field.stories.mdx
@@ -13,6 +13,11 @@ import { Form, Label, SelectField, anchorFormsEn } from "../src";
   decorators={[
     (Story) => {
       const translations = {
+        hints: {
+          select_field_example: {
+            select_example: "Optional helper text"
+          }
+        },
         labels: {
           select_field_example: {
             select_example: "Select example"
@@ -53,11 +58,11 @@ export const Template = (args) => {
         options={options}
         name="selectExample"
         rules={{ required: true }}
-        {...args} 
+        {...args}
       />
       <Flex>
         <Button colorScheme="basic" onClick={(e) => { e.preventDefault(); form.reset() }}>Reset</Button>
-        <Button colorScheme="primary">Submit</Button>
+        <Button colorScheme="primary" type="submit">Submit</Button>
       </Flex>
     </Form>
   );

--- a/packages/components/form/stories/text_field.stories.mdx
+++ b/packages/components/form/stories/text_field.stories.mdx
@@ -10,6 +10,11 @@ import { Form, TextField, TextArea, anchorFormsEn } from "../src";
 <Meta
   title="Components / Forms / TextField"
   component={TextField}
+  argTypes={{
+    width: {
+     control: { type: "text" },
+    }
+  }}
   decorators={[
     (Story) => {
       const translations = {
@@ -35,7 +40,7 @@ import { Form, TextField, TextArea, anchorFormsEn } from "../src";
   parameters={{
     layout: "centered",
     controls: {
-      include: ["disabled"]
+      include: ["label", "disabled", "width"]
     }
   }}
 />
@@ -47,7 +52,7 @@ export const Template = (args) => {
       <TextField name="textField" rules={{ required: true }} {...args} />
       <Flex>
         <Button colorScheme="basic" onClick={(e) => { e.preventDefault(); form.reset() }}>Reset</Button>
-        <Button colorScheme="primary">Submit</Button>
+        <Button colorScheme="primary" type="submit">Submit</Button>
       </Flex>
     </Form>
   );
@@ -56,7 +61,7 @@ export const Template = (args) => {
 ## Basic Usage
 
 <Canvas>
-  <Story args={{ disabled: false }} name="TextField">
+  <Story args={{ width: "input", disabled: false }} name="TextField">
     {Template.bind({})}
   </Story>
 </Canvas>
@@ -64,7 +69,7 @@ export const Template = (args) => {
 # TextArea
 
 <Canvas>
-  <Story args={{ disabled: false, Component: TextArea }} name="TextArea TextField">
+  <Story args={{ width: "input", disabled: false, Component: TextArea }} name="TextArea TextField">
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/packages/components/form/stories/text_field.stories.mdx
+++ b/packages/components/form/stories/text_field.stories.mdx
@@ -18,6 +18,11 @@ import { Form, TextField, TextArea, anchorFormsEn } from "../src";
   decorators={[
     (Story) => {
       const translations = {
+        hints: {
+          text_field_example: {
+            text_field: "Optional helper text"
+          }
+        },
         labels: {
           text_field_example: {
             text_field: "Example"


### PR DESCRIPTION
We want to change layout props in FormField in Infirmary.
    
Also removes redundant Box from TextField
    
The change of default type=button for Button broke storybook: now we
have to declare type=submit explicitly.

https://app.asana.com/0/1203925238636526/1204081792553150