### PR TITLE
Improve LegacyText types

### DIFF
--- a/packages/components/legacy_text/package.json
+++ b/packages/components/legacy_text/package.json
@@ -7,7 +7,6 @@
     "dist"
   ],
   "dependencies": {
-    "@buoysoftware/anchor-layout": "^0.31.1",
     "@buoysoftware/anchor-typography": "^0.31.1"
   },
   "scripts": {

--- a/packages/components/legacy_text/src/legacy_text.tsx
+++ b/packages/components/legacy_text/src/legacy_text.tsx
@@ -1,8 +1,15 @@
-import { BoxProps } from "@buoysoftware/anchor-layout";
-import { Body, Heading, Subheading } from "@buoysoftware/anchor-typography";
-import { TypographyProps } from "styled-system";
+import { Body, BodyProps, Heading, HeadingProps, Subheading, SubheadingProps } from "@buoysoftware/anchor-typography";
 
-export type LegacyTextVariant =
+type HeadingVariant = 
+| "subtitle"
+| "label"
+| "headline1"
+| "headline2"
+| "headline3";
+
+type SubheadingVariant = "overline"
+
+type BodyVariant = 
   | "bodyLargeBold"
   | "bodyLargeMedium"
   | "bodyMediumBold"
@@ -12,107 +19,78 @@ export type LegacyTextVariant =
   | "bodySmallRegularItalic"
   | "caption"
   | "error"
-  | "headline1"
-  | "headline2"
-  | "headline3"
-  | "input"
-  | "label"
-  | "overline"
-  | "subtitle";
+  | "input";
+
+export type LegacyTextVariant =
+  | BodyVariant
+  | HeadingVariant
+  | SubheadingVariant;
 
 interface OwnProps {
   variant?: LegacyTextVariant;
 }
 
-export type TextProps = BoxProps & TypographyProps & OwnProps;
+type HeadingVariantProps = { variant: HeadingVariant } & Omit<HeadingProps, 'size'>;
+type SubheadingVariantProps = { variant: SubheadingVariant } & Omit<SubheadingProps, 'size'>;
+type BodyVariantProps = { variant: BodyVariant } & Omit<BodyProps, 'size'>;
 
-export const LegacyText: React.FC<TextProps> = ({
-  children,
-  variant,
-  ...props
-}): React.ReactElement => {
-  switch (variant) {
+export type TextProps = (HeadingVariantProps | SubheadingVariantProps | BodyVariantProps) & OwnProps;
+
+export const LegacyText: React.FC<TextProps> = (props): React.ReactElement => {
+  switch (props.variant) {
     case "bodyLargeBold":
       return (
-        <Body strong size="l" {...props}>
-          {children}
-        </Body>
+        <Body strong size="l" {...props} />
       );
     case "bodyLargeMedium":
       return (
-        <Body size="l" {...props}>
-          {children}
-        </Body>
+        <Body size="l" {...props} />
       );
     case "bodyMediumBold":
       return (
-        <Body strong size="m" {...props}>
-          {children}
-        </Body>
+        <Body strong size="m" {...props} />
       );
     case "bodyMediumMedium":
     case "input":
     case "error":
       return (
-        <Body size="m" {...props}>
-          {children}
-        </Body>
+        <Body size="m" {...props} />
       );
     case "bodySmallRegular":
     case "caption":
       return (
-        <Body size="s" {...props}>
-          {children}
-        </Body>
+        <Body size="s" {...props} />
       );
     case "bodySmallRegularBold":
       return (
-        <Body size="s" strong {...props}>
-          {children}
-        </Body>
+        <Body size="s" strong {...props} />
       );
     case "bodySmallRegularItalic":
       return (
-        <Body size="s" emphasized {...props}>
-          {children}
-        </Body>
+        <Body size="s" emphasized {...props} />
       );
     case "headline1":
       return (
-        <Heading size="xl" {...props}>
-          {children}
-        </Heading>
+        <Heading size="xl" {...props} />
       );
     case "headline2":
       return (
-        <Heading size="l" {...props}>
-          {children}
-        </Heading>
+        <Heading size="l" {...props} />
       );
     case "headline3":
       return (
-        <Heading size="m" {...props}>
-          {children}
-        </Heading>
+        <Heading size="m" {...props} />
       );
     case "overline":
       return (
-        <Subheading size="s" {...props}>
-          {children}
-        </Subheading>
+        <Subheading size="s" {...props} />
       );
     case "subtitle":
     case "label":
       return (
-        <Heading size="s" {...props}>
-          {children}
-        </Heading>
+        <Heading size="s" {...props} />
       );
     default:
-      return (
-        <Body size="m" {...props}>
-          {children}
-        </Body>
-      );
+      throw "unsupported variant";
   }
 };

--- a/packages/components/typography/src/subheading.tsx
+++ b/packages/components/typography/src/subheading.tsx
@@ -8,7 +8,7 @@ interface OwnProps {
   size: SubheadingSize;
 }
 
-type SubheadingProps = TextProps & OwnProps;
+export type SubheadingProps = TextProps & OwnProps;
 
 export const SUBHEADING_TOKEN_MAPPING: Record<
   SubheadingSize,


### PR DESCRIPTION
`LegacyText` would not allow passing of props such as `textTransform` because its typing was to narrow. It now accepts all the props for the rendered anchor-ui component which is decided upon by the `variant` prop.