### PR TITLE
Introduce LegacyTrans component

### DIFF
--- a/packages/components/legacy_trans/clean-package.config.json
+++ b/packages/components/legacy_trans/clean-package.config.json
@@ -1,0 +1,6 @@
+{
+  "replace": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts"
+  }
+}

--- a/packages/components/legacy_trans/package.json
+++ b/packages/components/legacy_trans/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@buoysoftware/anchor-ui-legacy-trans",
+  "version": "0.31.1",
+  "description": "Legacy support for Trans component to assist in migrating to anchor-ui",
+  "main": "src/index.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@buoysoftware/anchor-typography": "^0.31.1"
+  },
+  "scripts": {
+    "build": "tsc -outDir dist",
+    "compile": "tsc --noEmit",
+    "postpack": "clean-package restore",
+    "prepack": "clean-package"
+  }
+}

--- a/packages/components/legacy_trans/src/index.ts
+++ b/packages/components/legacy_trans/src/index.ts
@@ -1,0 +1,1 @@
+export { LegacyTrans } from "./legacy_trans";

--- a/packages/components/legacy_trans/src/legacy_trans.tsx
+++ b/packages/components/legacy_trans/src/legacy_trans.tsx
@@ -1,0 +1,32 @@
+import { Body } from "@buoysoftware/anchor-typography";
+
+import { KeyPrefix, Namespace, TFuncKey } from "i18next";
+import { Trans as ReactI18nTrans, TransProps } from "react-i18next";
+
+const LegacyTrans = <
+  K extends TFuncKey<N, TKPrefix> extends infer A ? A : never,
+  N extends Namespace,
+  TKPrefix extends KeyPrefix<N> = undefined,
+  E = React.HTMLProps<HTMLDivElement>
+>(
+  props: TransProps<K, N, TKPrefix, E>
+): React.ReactElement => {
+  return (
+    <ReactI18nTrans
+      components={{
+        BodyMediumBold: <Body strong as="span" color="inherit" size="m" />,
+        BodySmallRegularBold: (
+          <Body strong as="span" color="inherit" size="s" />
+        ),
+        BodySmallRegularBoldError: (
+          <Body strong as="span" color="critical" size="s" />
+        ),
+      }}
+      {...props}
+    />
+  );
+};
+
+LegacyTrans.displayName = "LegacyTrans";
+
+export { LegacyTrans };

--- a/packages/components/legacy_trans/stories/legacy_trans.stories.mdx
+++ b/packages/components/legacy_trans/stories/legacy_trans.stories.mdx
@@ -1,0 +1,105 @@
+import { Canvas, Story } from "@storybook/addon-docs";
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import { LegacyTrans } from "../src";
+
+<Meta
+  title="anchor-ui-compat / LegacyTrans"
+  component={LegacyTrans}
+  decorators={[
+    (Story) => {
+      const translations = {
+        formats: {
+          bodyMediumBold: "<BodyMediumBold>Body Medium Bold</BodyMediumBold>",
+          bodySmallBold: "<BodySmallRegularBold>Body Small Bold</BodySmallRegularBold>",
+          error: "<BodySmallRegularBoldError>Error message</BodySmallRegularBoldError>"
+        }
+      }
+      i18n.use(initReactI18next).init({
+        lng: "en",
+        ns: ["testNs"],
+        resources: {
+          en: {
+            testNs: translations,
+          },
+        },
+      });
+      return Story()
+    }
+  ]}
+  parameters={{ layout: "centered" }}
+/>
+
+export const Template = (args) => {
+  return <LegacyTrans {...args} />
+};
+
+# LegacyTrans
+
+The LegacyTrans component provides a compatability bridge to migrate existing
+applications to use AnchorUI incrementally. It maps the font size and color 
+scheme variants used in legacy components to the new AnchorUI equivalents.
+
+## Import
+
+```javascript
+import { LegacyTrans } from "@buoysoftware/anchor-ui-compat";
+```
+
+## Basic Usage
+
+<Canvas>
+  <Story name="LegacyTrans" args={{ children: "LegacyTrans" }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Component Variants
+These are achieved by leveraging the i18next component prop and wrapping the
+text in the translation file in the corresponding tag. The LegacyTrans
+component maps prop name indexes from Wharf/Buoy onto anchor-ui components.
+
+<br />
+
+### BodyMediumBold
+
+<Canvas>
+  <Story
+    name="LegacyTransMediumBold"
+    args={{
+      i18nKey: "formats.bodyMediumBold",
+      ns: "testNs"
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### BodySmallRegularBold
+
+<Canvas>
+  <Story
+    name="LegacyTransSmallBold"
+    args={{
+      i18nKey: "formats.bodySmallBold",
+      ns: "testNs"
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### BodySmallRegularBoldError
+
+<Canvas>
+  <Story
+    name="LegacyTransSmallBoldError"
+    args={{
+      i18nKey: "formats.error",
+      ns: "testNs"
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/components/legacy_trans/tsconfig.json
+++ b/packages/components/legacy_trans/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["src", "index.ts", "../../../@types"]
+}

--- a/packages/components/trans/index.ts
+++ b/packages/components/trans/index.ts
@@ -1,0 +1,1 @@
+export * from "./trans";

--- a/packages/components/trans/index.ts
+++ b/packages/components/trans/index.ts
@@ -1,1 +1,0 @@
-export * from "./trans";


### PR DESCRIPTION
In order to support migrating to anchor-ui in a more smooth fashion, we needed to introduce a Trans component that mapped current Wharf theme values to current anchor-ui style patterns.

<details><summary>Screenshot</summary>

<img width="1973" alt="Screenshot 2023-03-06 at 5 46 05 PM" src="https://user-images.githubusercontent.com/3165407/223277910-5a0a39f2-1004-4c33-b2a1-65926c2c94d3.png">
</details>