### PR TITLE
Move legacy component stories to anchor-ui-compat

### DIFF
--- a/packages/components/legacy_connection_table/stories/legacy_connection_table.stories.mdx
+++ b/packages/components/legacy_connection_table/stories/legacy_connection_table.stories.mdx
@@ -6,7 +6,7 @@ import LinkTo from "@storybook/addon-links/react";
 import { LegacyConnectionTable } from "../src";
 
 <Meta
-  title="Components / LegacyConnectionTable"
+  title="anchor-ui-compat / LegacyConnectionTable"
   component={LegacyConnectionTable}
 />
 

--- a/packages/components/legacy_table/stories/legacy_table.stories.mdx
+++ b/packages/components/legacy_table/stories/legacy_table.stories.mdx
@@ -5,7 +5,7 @@ import { Canvas, Story } from "@storybook/addon-docs";
 import { LegacyTable } from "../src";
 
 <Meta
-  title="Components / LegacyTable"
+  title="anchor-ui-compat / LegacyTable"
   component={LegacyTable}
   parameters={{
     controls: {


### PR DESCRIPTION
These stories were incorrectly put under "Components" rather than "Anchor-ui-compat" in storybook