### PR TITLE
Fix typing in TextProps from LegacyText

### DIFF
--- a/packages/components/legacy_text/src/legacy_text.tsx
+++ b/packages/components/legacy_text/src/legacy_text.tsx
@@ -29,7 +29,7 @@ export type LegacyTextVariant =
 type HeadingVariantProps = { variant: HeadingVariant } & Omit<HeadingProps, 'size'>;
 type SubheadingVariantProps = { variant: SubheadingVariant } & Omit<SubheadingProps, 'size'>;
 type BodyVariantProps = { variant: BodyVariant } & Omit<BodyProps, 'size'>;
-type NoVariantProps = Omit<BodyProps, 'size'>;
+type NoVariantProps = { variant?: undefined } & Omit<BodyProps, 'size'>;
 
 export type TextProps = HeadingVariantProps | SubheadingVariantProps | BodyVariantProps | NoVariantProps;
 


### PR DESCRIPTION
The following doesn't work when importing `TextProps` from the `LegacyText` component.

```ts
type A = TextProps["variant"];
```

This makes a type update to allow this, so compatibility works for existing consumers