### PR TITLE
Update useTranslatedOptions to use generic

### DIFF
--- a/packages/hooks/use_translated_options/src/use_translated_options.ts
+++ b/packages/hooks/use_translated_options/src/use_translated_options.ts
@@ -7,17 +7,15 @@ interface TranslatableComponentProps {
   tOptions?: UseTranslationParameters[1];
 }
 
-type Value = string;
-
-interface Option {
+interface Option<V> {
   label: string;
-  value: Value;
+  value: V;
 }
 
-export function useTranslatedOptions(
-  values: Value[],
+export function useTranslatedOptions<V extends string>(
+  values: V[],
   { tNamespace, tOptions }: TranslatableComponentProps
-): Option[] {
+): Option<V>[] {
   const { t } = useTranslation(tNamespace, tOptions);
 
   return values.map((value) => ({


### PR DESCRIPTION
We ran into an issue when trying to use typescript enum values as an option value. Typescript would complain that the option value was a string if we had strong types against an enum elsewhere. This utilizes a generic so we can keep types consistent.