### PR TITLE
Make i18n packages peer dependencies

### DIFF
--- a/packages/components/form/package.json
+++ b/packages/components/form/package.json
@@ -19,15 +19,19 @@
     "@buoysoftware/anchor-layout": "^0.31.1",
     "@buoysoftware/anchor-theme": "^0.31.1",
     "@buoysoftware/anchor-typography": "^0.31.2",
-    "i18next": "^22.4.9",
     "iconoir-react": "^6.2.1",
     "libphonenumber-js": "^1.10.21",
     "lodash": "*",
     "react-hook-form": "^7.42.1",
-    "react-i18next": "^12.1.4",
     "react-select": "^5.7.0"
   },
+  "peerDependencies": {
+    "i18next": "^22.4.9",
+    "react-i18next": "^12.1.4"
+  },
   "devDependencies": {
+    "i18next": "^22.4.9",
+    "react-i18next": "^12.1.4",
     "jest": "^29.3.1",
     "ts-jest": "^29.0.4",
     "ts-node": "^10.9.1"

--- a/packages/components/legacy_table/package.json
+++ b/packages/components/legacy_table/package.json
@@ -13,8 +13,14 @@
     "@buoysoftware/anchor-layout": "^0.31.1",
     "@buoysoftware/anchor-table": "^0.31.1",
     "@buoysoftware/anchor-ui-legacy-text": "^0.31.4",
+    "lodash": "^4.17.21"
+  },
+  "peerDependencies": {
     "i18next": "^22.4.9",
-    "lodash": "^4.17.21",
+    "react-i18next": "^12.1.4"
+  },
+  "devDependencies": {
+    "i18next": "^22.4.9",
     "react-i18next": "^12.1.4"
   }
 }

--- a/packages/components/page_template/package.json
+++ b/packages/components/page_template/package.json
@@ -6,10 +6,13 @@
   "dependencies": {
     "@buoysoftware/anchor-layout": "^0.31.1",
     "@buoysoftware/anchor-loading-indicator": "^0.31.1",
-    "@buoysoftware/anchor-typography": "^0.31.2",
+    "@buoysoftware/anchor-typography": "^0.31.2"
+  },
+  "peerDependencies": {
     "react-i18next": "^12.1.5"
   },
   "devDependencies": {
+    "react-i18next": "^12.1.5",
     "jest": "^29.3.1"
   },
   "scripts": {

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -7,7 +7,9 @@
     "@buoysoftware/anchor-button": "^0.31.2",
     "@buoysoftware/anchor-layout": "^0.31.1",
     "@buoysoftware/anchor-typography": "^0.31.2",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.21"
+  },
+  "peerDependencies": {
     "react-i18next": "^12.1.4"
   },
   "scripts": {
@@ -18,6 +20,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "react-i18next": "^12.1.4",
     "jest": "^29.3.1",
     "ts-jest": "^29.0.4",
     "ts-node": "^10.9.1"

--- a/packages/hooks/use_translated_options/package.json
+++ b/packages/hooks/use_translated_options/package.json
@@ -10,10 +10,11 @@
     "prepack": "clean-package",
     "test": "jest"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react-i18next": "^12.1.4"
   },
   "devDependencies": {
+    "react-i18next": "^12.1.4",
     "jest": "^29.3.1",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1"


### PR DESCRIPTION
When bringing in anchor-ui components that used translations, the translation keys would not get translated. For example, using the `Table` component would show "empty_message" instead of the actual translated message when a table is empty. This occurred because the `anchor-ui` package used a different version of the i18n packages that were installed by the consumer.

This PR makes the i18n packages a peer dependency so the same package is used by both the consumer and the anchor-ui library