### PR TITLE
Fix cell render bug in LegacyTable

### DIFF
--- a/packages/components/legacy_table/src/legacy_table.tsx
+++ b/packages/components/legacy_table/src/legacy_table.tsx
@@ -103,7 +103,7 @@ export const LegacyTable = <RecordData,>({ cellConfigs, ...props }: LegacyTableP
     const render = cellConfig.render || translationKeyPrefix || cellConfig.t ? (record: RecordData): React.ReactNode => {
       const value = get(record, dataKey, undefined);
       const hasNoValue = value === null || value === undefined;
-      const cellT = translationKeyPrefix ? keyPrefixedCellT(unprefixedCellT, value) : unprefixedCellT;
+      const cellT = translationKeyPrefix ? keyPrefixedCellT(unprefixedCellT, translationKeyPrefix) : unprefixedCellT;
 
       if (cellConfig.render) return cellConfig.render(record, actualT, cellT);
       if (hasNoValue) return renderPlaceholder(record);


### PR DESCRIPTION
There was a bug that the `translationKeyPrefix` would not properly get used when supplied to the `cellConfigs` in the `LegacyTable`. This fixes that bug