### PR TITLE
Update PageHeader to support children

### DIFF
--- a/packages/components/page_template/src/page_header.tsx
+++ b/packages/components/page_template/src/page_header.tsx
@@ -2,12 +2,14 @@ import { Flex, FlexProps } from "@buoysoftware/anchor-layout";
 import { Heading } from "@buoysoftware/anchor-typography";
 
 interface OwnProps {
+  children?: React.ReactNode;
   title: string;
 }
 
 type PageHeaderProps = OwnProps & Omit<FlexProps, "gridArea">;
 
 export const PageHeader: React.FC<PageHeaderProps> = ({
+  children,
   title,
   ...props
 }): React.ReactElement => {
@@ -19,11 +21,13 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
       mb="l"
       ml="page.gutterX"
       mt="xxxl"
+      alignItems="center"
       {...props}
     >
-      <Heading as="h1" size="xl">
+      <Heading as="h1" mr="xs" size="xl">
         {title}
       </Heading>
+      {children}
     </Flex>
   );
 };

--- a/packages/components/page_template/stories/page_header.stories.mdx
+++ b/packages/components/page_template/stories/page_header.stories.mdx
@@ -1,0 +1,35 @@
+import { Canvas, Story } from "@storybook/addon-docs";
+
+import { Badge } from "@buoysoftware/anchor-badge";
+import { PageHeader } from "../src";
+
+<Meta
+  title="Components / PageHeader"
+  component={PageHeader}
+  parameters={{
+    layout: "centered"
+  }}
+/>
+
+
+export const Template = (args) => {
+  return <PageHeader {...args} />
+};
+
+## Basic Usage
+
+<Canvas>
+  <Story
+    name="PageHeader"
+    args={{ title: "My Page Title" }}
+  >{Template.bind({})}</Story>
+</Canvas>
+
+## With Children
+
+<Canvas>
+  <Story
+    name="PageHeader with Children"
+    args={{ title: "Version 005", children: <Badge bg="background.selectedSubdued">Draft</Badge> }}
+  >{Template.bind({})}</Story>
+</Canvas>


### PR DESCRIPTION
Example use case is to display a badge as part of the PageHeader.

<img width="1616" alt="image" src="https://user-images.githubusercontent.com/105694/224215853-7b461b56-52c7-42a7-9507-e1e6206c1e2b.png">
