### PR TITLE
Update AppTemplate components to overflowY auto

### DIFF
--- a/packages/components/app_template/src/app_content.tsx
+++ b/packages/components/app_template/src/app_content.tsx
@@ -11,7 +11,7 @@ export const AppContent: React.FC<AppContentProps> = ({
   ...props
 }): React.ReactElement => {
   return (
-    <Box gridArea="app-content" overflowY="scroll" {...props}>
+    <Box gridArea="app-content" overflowY="auto" {...props}>
       {children}
     </Box>
   );

--- a/packages/components/app_template/src/app_side_nav.tsx
+++ b/packages/components/app_template/src/app_side_nav.tsx
@@ -11,7 +11,7 @@ export const AppSideNav: React.FC<AppSideNavProps> = ({
   ...props
 }): React.ReactElement => {
   return (
-    <Box gridArea="side-nav" {...props}>
+    <Box gridArea="side-nav" overflowY="auto" {...props}>
       {children}
     </Box>
   );


### PR DESCRIPTION
Instead of always display the scroll bar, only display it when it's necessary. Also adds it to the AppSideNav in case that ever grows taller than the viewport.