### PR TITLE
Update storybook to reflect badge default text

### DIFF
--- a/packages/components/badge/stories/badge.stories.mdx
+++ b/packages/components/badge/stories/badge.stories.mdx
@@ -22,7 +22,7 @@ export const Template = (args) => {
   <Story
     name="Badge"
     args={{
-      textProps: { color: "#000000" },
+      textProps: { color: "text.primary" },
       backgroundColor: "background.successSubdued",
       children: "Badge"
     }}


### PR DESCRIPTION
Using #000000 caused some confusion as to what the default is when running design review.