### PR TITLE
useTranslatedOptions v2

### DIFF
--- a/packages/hooks/use_translated_options/__specs__/use_translated_options.spec.tsx
+++ b/packages/hooks/use_translated_options/__specs__/use_translated_options.spec.tsx
@@ -22,7 +22,7 @@ describe("useTranslatedOptions", () => {
     },
   });
 
-  it("translates the options", () => {
+  it("exposes options", () => {
     const { result } = renderHook(() =>
       useTranslatedOptions(["option_1", "option_2"], {
         tNamespace: "myNamespace",
@@ -30,9 +30,49 @@ describe("useTranslatedOptions", () => {
       })
     );
 
-    expect(result.current).toEqual([
-      { label: "Option 1", value: "option_1" },
-      { label: "Option 2", value: "option_2" },
-    ]);
+    expect(result.current.options).toBeDefined();
+  });
+
+  it("exposes getOptionFromValue", () => {
+    const { result } = renderHook(() =>
+      useTranslatedOptions(["option_1", "option_2"], {
+        tNamespace: "myNamespace",
+        tOptions: { keyPrefix: "mock_prefix" },
+      })
+    );
+
+    expect(result.current.getOptionFromValue).toBeDefined();
+  });
+
+  describe("options", () => {
+    it("is a set of translated the options", () => {
+      const { result } = renderHook(() =>
+        useTranslatedOptions(["option_1", "option_2"], {
+          tNamespace: "myNamespace",
+          tOptions: { keyPrefix: "mock_prefix" },
+        })
+      );
+
+      expect(result.current.options).toEqual([
+        { label: "Option 1", value: "option_1" },
+        { label: "Option 2", value: "option_2" },
+      ]);
+    });
+  });
+
+  describe("getOptionFromValue", () => {
+    it("returns an option from a given value", () => {
+      const { result } = renderHook(() =>
+        useTranslatedOptions(["option_1", "option_2"], {
+          tNamespace: "myNamespace",
+          tOptions: { keyPrefix: "mock_prefix" },
+        })
+      );
+
+      expect(result.current.getOptionFromValue("option_1")).toEqual({
+        label: "Option 1",
+        value: "option_1",
+      });
+    });
   });
 });

--- a/packages/hooks/use_translated_options/src/use_translated_options.ts
+++ b/packages/hooks/use_translated_options/src/use_translated_options.ts
@@ -12,14 +12,25 @@ interface Option<V> {
   value: V;
 }
 
+interface ReturnType<V> {
+  options: Option<V>[]
+  getOptionFromValue: (value: V) => Option<V> | undefined;
+}
+
 export function useTranslatedOptions<V extends string>(
   values: V[],
   { tNamespace, tOptions }: TranslatableComponentProps
-): Option<V>[] {
+): ReturnType<V> {
   const { t } = useTranslation(tNamespace, tOptions);
 
-  return values.map((value) => ({
+  const options = values.map((value) => ({
     label: t(value),
     value,
   }));
+
+  const getOptionFromValue = (value: V): Option<V> | undefined => {
+    return options.find((option) => option.value === value )
+  }
+
+  return { options, getOptionFromValue }
 }

--- a/packages/hooks/use_translated_options/stories/use_translated_options.stories.mdx
+++ b/packages/hooks/use_translated_options/stories/use_translated_options.stories.mdx
@@ -5,6 +5,8 @@
 The `useTranslatedOptions` hook is a convience hook for taking a set of data
 values and generating options for use in select, radio, or check box collections.
 
+Additionally, it exposes a utility for getting an option object from a given value.
+
 This depends on [react-i18next] for translating the options.
 
 ## Import
@@ -19,15 +21,21 @@ import { useTranslatedOptions } from "@buoysoftware/anchor-ui";
 const MyComponent = () => {
   const values = ["option_1", "option_2"];
 
-  // Returns an arry of objecst like:
-  // [
-  //  { value: "option_1", label: "Option 1" },
-  //  { value: "option_2", label: "Option 2" }
-  // ]
-  const options = useTranslatedOptions(values, { tNamespace: "myNamespace" });
+  // Returns an object like:
+  // { 
+  //    getOptionFromValue: (value) => ({ value: value, label: "Translated Value Label" })
+  //    options: [
+  //      { value: "option_1", label: "Option 1" },
+  //      { value: "option_2", label: "Option 2" }
+  //    ]
+  // }
+  const { getOptionFromValue, options } = useTranslatedOptions(values, { tNamespace: "myNamespace" });
+
+  const defaultOption = getOptionFromValue("option_1");
 
   return (
     <>
+      <>The default option is {defaultOption.label}</>
       {options.map(({ value, label }) => (
         <label key={value}>
           <input type="radio" name="myRadio" value={value} />


### PR DESCRIPTION
Instead of returning an array of options, this hook has been updated to
return an object with keys for options and getOptionFromValue. The
options key preserves the original return value of translated options
while getOptionFromValue is a utility function built from the option set
to make it easier to find the option object from a given value.