### PR TITLE
Small tweak to FormField error width

### DIFF
--- a/packages/components/form/src/form_field.tsx
+++ b/packages/components/form/src/form_field.tsx
@@ -58,7 +58,7 @@ export const FormField = styled(
           inputType={inputType}
           mt="xxs"
           name={name}
-          width="input"
+          width="100%"
         />
       </Box>
     );


### PR DESCRIPTION
The FormField component accepts BoxProps, allowing a user to set the width of the FormField to fit their needs. The ErrorMessage component width was hard-coded, causing the width of the error message to be 300px regardless of its parent's width. This updates the ErrorMessage to be 100% of its parent's width.

<details><summary>Screenshots</summary>
Before:<br/>
<br/>
<img width="524" alt="Screenshot 2023-03-22 at 3 48 19 PM" src="https://user-images.githubusercontent.com/3165407/227296878-de90fe5c-13d9-4c93-a3da-af2ceebbbb1d.png">
<br/>
<br/>
<br/>
After:<br/>
<br/>
<img width="528" alt="Screenshot 2023-03-23 at 1 45 33 PM" src="https://user-images.githubusercontent.com/3165407/227297236-6900292f-4d31-49d7-ac24-01eeb3e1967c.png">
</details>