### PR TITLE
Fix sortable table record caching

### DIFF
--- a/packages/components/table/__specs__/__snapshots__/sortable_table.spec.tsx.snap
+++ b/packages/components/table/__specs__/__snapshots__/sortable_table.spec.tsx.snap
@@ -108,7 +108,7 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
           font-size="font-size-100"
           font-weight="600"
         >
-          ID
+          Position
         </th>
         <th
           class="c2 c3"
@@ -116,7 +116,7 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
           font-size="font-size-100"
           font-weight="600"
         >
-          Status
+          Full Name
         </th>
       </tr>
     </thead>
@@ -133,7 +133,7 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
           aria-roledescription="sortable"
           class="c5 c6"
           color="text.primary"
-          data-testid="tr-1-td-id"
+          data-testid="tr-1-td-position"
           font-size="font-size-100"
           font-style="none"
           font-weight="400"
@@ -146,12 +146,12 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
         <td
           class="c7 c6"
           color="text.primary"
-          data-testid="tr-1-td-status"
+          data-testid="tr-1-td-name"
           font-size="font-size-100"
           font-style="none"
           font-weight="400"
         >
-          Good
+          Jerry Seinfeld
         </td>
       </tr>
       <tr
@@ -164,7 +164,7 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
           aria-roledescription="sortable"
           class="c5 c6"
           color="text.primary"
-          data-testid="tr-2-td-id"
+          data-testid="tr-2-td-position"
           font-size="font-size-100"
           font-style="none"
           font-weight="400"
@@ -177,12 +177,12 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
         <td
           class="c7 c6"
           color="text.primary"
-          data-testid="tr-2-td-status"
+          data-testid="tr-2-td-name"
           font-size="font-size-100"
           font-style="none"
           font-weight="400"
         >
-          Bad
+          George Costanza
         </td>
       </tr>
       <tr
@@ -195,7 +195,7 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
           aria-roledescription="sortable"
           class="c5 c6"
           color="text.primary"
-          data-testid="tr-3-td-id"
+          data-testid="tr-3-td-position"
           font-size="font-size-100"
           font-style="none"
           font-weight="400"
@@ -208,12 +208,12 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
         <td
           class="c7 c6"
           color="text.primary"
-          data-testid="tr-3-td-status"
+          data-testid="tr-3-td-name"
           font-size="font-size-100"
           font-style="none"
           font-weight="400"
         >
-          Ugly
+          Elaine Benes
         </td>
       </tr>
       <tr
@@ -226,7 +226,7 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
           aria-roledescription="sortable"
           class="c5 c6"
           color="text.primary"
-          data-testid="tr-4-td-id"
+          data-testid="tr-4-td-position"
           font-size="font-size-100"
           font-style="none"
           font-weight="400"
@@ -239,12 +239,12 @@ exports[`<SortableTable /> renders a sortable table 1`] = `
         <td
           class="c7 c6"
           color="text.primary"
-          data-testid="tr-4-td-status"
+          data-testid="tr-4-td-name"
           font-size="font-size-100"
           font-style="none"
           font-weight="400"
         >
-          Other
+          Cosmo Kramer
         </td>
       </tr>
     </tbody>

--- a/packages/components/table/__specs__/sortable_table.spec.tsx
+++ b/packages/components/table/__specs__/sortable_table.spec.tsx
@@ -4,38 +4,44 @@ import { SortableTable } from "../src/sortable_table";
 import { SortableTableCellConfig } from "../src/types";
 import { act, render } from "../test_utils";
 import { initReactI18next } from "react-i18next";
+import { useCallback, useState } from "react";
 
-interface Donation {
+interface Person {
   __typename: string;
   id: string;
-  status: string;
+  name: string;
+  position: number;
 }
 
-const cellConfigs: SortableTableCellConfig<Donation>[] = [
-  { dataKey: "id", sortHandle: true },
-  { dataKey: "status" },
+const cellConfigs: SortableTableCellConfig<Person>[] = [
+  { dataKey: "position", sortHandle: true },
+  { dataKey: "name" },
 ];
 
-const records: Donation[] = [
+const records: Person[] = [
   {
-    __typename: "Donation",
+    __typename: "Person",
     id: "1",
-    status: "Good",
+    name: "Jerry Seinfeld",
+    position: 1,
   },
   {
-    __typename: "Donation",
+    __typename: "Person",
     id: "2",
-    status: "Bad",
+    name: "George Costanza",
+    position: 2,
   },
   {
-    __typename: "Donation",
+    __typename: "Person",
     id: "3",
-    status: "Ugly",
+    name: "Elaine Benes",
+    position: 3,
   },
   {
-    __typename: "Donation",
+    __typename: "Person",
     id: "4",
-    status: "Other",
+    name: "Cosmo Kramer",
+    position: 4,
   },
 ];
 
@@ -43,8 +49,8 @@ describe("<SortableTable />", () => {
   const tables = {
     donations: {
       th: {
-        id: "ID",
-        status: "Status",
+        position: "Position",
+        name: "Full Name",
       },
     },
   };
@@ -73,8 +79,58 @@ describe("<SortableTable />", () => {
     expect(component.asFragment()).toMatchSnapshot();
   });
 
-  describe("sorting by mouse", () => {
-    it("fires callback with sorted items", async () => {
+  it("re-renders when records change", async () => {
+    const DummyComponent: React.FC = (): React.ReactElement => {
+      const [sortedRecords, setSortedRecords] = useState<Person[]>(records);
+
+      const reverseRows = useCallback(() => {
+        setSortedRecords((records) => [...records].reverse())
+      }, [])
+
+      return (
+        <>
+          <SortableTable
+            cellConfigs={cellConfigs}
+            name="donations"
+            recordIdKey="id"
+            records={sortedRecords}
+          />
+          <a href="#" onClick={reverseRows}>Reverse Rows</a>
+        </>
+      );
+    };
+    const user = userEvent.setup();
+    const component = render(<DummyComponent />);
+
+    expect(
+      component.queryAllByRole("button").map((element) => element.textContent)
+    ).toEqual(["1", "2", "3", "4"]);
+
+    const reverseRowsButton = component.getByText("Reverse Rows");
+    await act(() => user.click(reverseRowsButton));
+
+    expect(
+      component.queryAllByRole("button").map((element) => element.textContent)
+    ).toEqual(["4", "3", "2", "1"]);
+  });
+
+  describe("onSort", () => {
+    it("does not fire on initial render", () => {
+      const onSort = jest.fn();
+      render(
+        <SortableTable
+          cellConfigs={cellConfigs}
+          name="donations"
+          onSort={onSort}
+          recordIdKey="id"
+          records={records}
+        />
+      );
+
+      expect(onSort).not.toHaveBeenCalled();
+    });
+
+    it("fires when sorted by mouse", async () => {
       const user = userEvent.setup();
       const onSort = jest.fn();
       const component = render(
@@ -88,20 +144,18 @@ describe("<SortableTable />", () => {
       );
       const rows = component.queryAllByRole("button");
 
-      await act(() => user.pointer({ keys: "[MouseLeft>]", target: rows[3] }))
-      await act(() => user.pointer({ keys: "[/MouseLeft]", target: rows[0] }))
+      await act(() => user.pointer({ keys: "[MouseLeft>]", target: rows[3] }));
+      await act(() => user.pointer({ keys: "[/MouseLeft]", target: rows[0] }));
 
       expect(onSort).toHaveBeenCalledWith([
         records[3],
         records[0],
         records[1],
-        records[2]
-      ])
-    })
-  });
+        records[2],
+      ]);
+    });
 
-  describe("sorting by keyboard", () => {
-    it("fires callback with sorted items", async () => {
+    it("fires when sorted by keyboard", async () => {
       const user = userEvent.setup();
       const onSort = jest.fn();
       render(
@@ -114,19 +168,19 @@ describe("<SortableTable />", () => {
         />
       );
 
-      await act(() => user.keyboard("{Shift>}[Tab]{/Shift}")) // Focus last row
-      await act(() => user.keyboard("[Space]")) // Activate "Drag" Start
-      await act(() => user.keyboard("[ArrowUp]")) // "Drag" up
-      await act(() => user.keyboard("[ArrowUp]")) // "Drag" up
-      await act(() => user.keyboard("[ArrowUp]")) // "Drag" up
-      await act(() => user.keyboard("[Space]")) // End "Drag"
+      await act(() => user.keyboard("{Shift>}[Tab]{/Shift}")); // Focus last row
+      await act(() => user.keyboard("[Space]")); // Activate "Drag" Start
+      await act(() => user.keyboard("[ArrowUp]")); // "Drag" up
+      await act(() => user.keyboard("[ArrowUp]")); // "Drag" up
+      await act(() => user.keyboard("[ArrowUp]")); // "Drag" up
+      await act(() => user.keyboard("[Space]")); // End "Drag"
 
       expect(onSort).toHaveBeenCalledWith([
         records[3],
         records[0],
         records[1],
-        records[2]
-      ])
-    })
+        records[2],
+      ]);
+    });
   });
 });

--- a/packages/components/table/stories/sortable_table.stories.mdx
+++ b/packages/components/table/stories/sortable_table.stories.mdx
@@ -1,7 +1,8 @@
-import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
-import { Canvas, Story } from "@storybook/addon-docs";
 import LinkTo from '@storybook/addon-links/react';
+import i18n from "i18next";
+import { Canvas, Story } from "@storybook/addon-docs";
+import { initReactI18next } from "react-i18next";
+import { useCallback, useState } from "react";
 
 import { SortableRowHandle, SortableTable } from "../src";
 
@@ -21,10 +22,9 @@ export const Template = ({ cellProps = () => ({}), ...args }) => {
             empty_message: "No donors to display",
             th: {
               name: "Donor Name",
+              position: "Sort Order",
               id: "Donor ID",
-              deferred: "Deferred",
-              my_facility_name: "Assigned Center",
-              level: "Level"
+              facility: "Assigned Center",
             },
           }
         }
@@ -32,19 +32,22 @@ export const Template = ({ cellProps = () => ({}), ...args }) => {
     },
   });
   const CELL_CONFIGS = [
-    { dataKey: "name", sortHandle: true },
+    { dataKey: "position", sortHandle: true },
+    { dataKey: "name"},
     { dataKey: "id" },
-    { dataKey: "myFacility.name" },
-    { dataKey: "level" },
+    { dataKey: "facility" },
   ];
-  const records = [
-    { name: "Jerry Seinfeld", id: 1, myFacility: { name: "Paris " }, level: 1 },
-    { name: "Cosmo Kramer", id: 2, myFacility: { name: "Paris " }, level: 7 },
-    { name: "Elaine Benes", id: 3, myFacility: { name: "Paris " }, level: 4 },
-  ]
-  const onSort = (sortedRecords) => {
+  const [records, setRecords] = useState([
+    { position: 1, name: "Jerry Seinfeld", id: 1, facility: "Paris" },
+    { position: 2, name: "Cosmo Kramer", id: 2, facility: "Paris" },
+    { position: 3, name: "Elaine Benes", id: 3, facility: "Paris" },
+  ])
+  const onSort = useCallback((sortedRecords) => {
     console.log("Sorted to: ", sortedRecords.map(({ name }) => name).join(", "))
-  }
+    setRecords(sortedRecords.map((record, index) => {
+      return { ...record, position: index + 1 }
+    }))
+  }, [])
   return (
     <SortableTable
       cellConfigs={CELL_CONFIGS}


### PR DESCRIPTION
The sortable table was not re-rendering when records changed. This
update adds an effect for updating the sortedRecords state when records
is changed externally.

Additionally, this updates the logic for firing the onSort to be more
performant and predictable.
