### PR TITLE
Add data-testid to dropdown menu item

### DIFF
--- a/packages/components/dropdown_menu/src/dropdown_menu_item.tsx
+++ b/packages/components/dropdown_menu/src/dropdown_menu_item.tsx
@@ -10,6 +10,7 @@ type DropdownMenuItemProps = OwnProps & Omit<BodyProps, "size">;
 
 export const DropdownMenuItem = styled(Body).attrs<DropdownMenuItemProps>(
   () => ({
+    "data-testid": "dropdown-menu-item",
     textDecoration: "none",
     size: "m",
     py: "xs",


### PR DESCRIPTION
Allows us to use a data-testid instead of relying on an `a` or `p` tag