### PR TITLE
WIP: Update font stack

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,8 +1,3 @@
-<link
-  href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&amp;display=swap"
-  rel="stylesheet"
-/>
-
 <style>
   /* http://meyerweb.com/eric/tools/css/reset/ 
    v2.0 | 20110126
@@ -96,10 +91,10 @@
     font-size: 100%;
     font: inherit;
     vertical-align: baseline;
-    font-family: -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI,
-      Roboto, Helvetica Neue, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+      "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+      "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+      "Noto Color Emoji";
   }
   /* HTML5 display-role reset for older browsers */
   article,

--- a/__mocks__/fileMock.ts
+++ b/__mocks__/fileMock.ts
@@ -1,0 +1,1 @@
+export default "test-file-stub";

--- a/packages/components/form/src/input/styled_input_wrapper.tsx
+++ b/packages/components/form/src/input/styled_input_wrapper.tsx
@@ -13,8 +13,10 @@ interface OwnProps {
 export type StyledInputWrapperProps = BoxProps & OwnProps;
 
 export const StyledInputWrapper = styled(Box)<StyledInputWrapperProps>`
-  font-family: -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI,
-    Roboto, Helvetica Neue, sans-serif;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   display: inline-block;
   background-color: ${({ theme }) => theme.colors.white};
   border: 1px solid ${({ theme }) => theme.colors.border.defualt};

--- a/packages/components/form/src/text_area/styled_text_area.tsx
+++ b/packages/components/form/src/text_area/styled_text_area.tsx
@@ -10,8 +10,10 @@ export type StyledTextAreaProps = OwnProps &
   React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
-  font-family: -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI,
-    Roboto, Helvetica Neue, sans-serif;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   resize: none;
   outline: none;
   border: 1px solid ${({ theme }) => theme.colors.border.defualt};

--- a/packages/components/toast_container/src/anchor_toast_container.tsx
+++ b/packages/components/toast_container/src/anchor_toast_container.tsx
@@ -25,8 +25,10 @@ export const AnchorToastContainer = styled(ToastContainer)`
   }
 
   .Toastify__toast-body {
-    font-family: -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI,
-      Roboto, Helvetica Neue, sans-serif;
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+      "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+      "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+      "Noto Color Emoji";
     font-size: ${({ theme }) => theme.fontSizes["font-size-100"]};
     font-weight: ${({ theme }) => theme.fontWeights.semibold};
     margin: 0;

--- a/packages/components/typography/src/text.tsx
+++ b/packages/components/typography/src/text.tsx
@@ -25,10 +25,10 @@ export type TextProps = BoxProps &
   LegacyHtmlProps;
 
 export const Text = styled(Box)<TextProps>`
-  font-family: -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI,
-    Roboto, Helvetica Neue, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
 
   ${typography}
   ${textTransform}

--- a/packages/components/typography/stories/typography.stories.tsx
+++ b/packages/components/typography/stories/typography.stories.tsx
@@ -87,24 +87,11 @@ export const Introduction = () => {
 
             <Box mt="m" padding="l" bg="#F5F6F7">
               <Text as="pre" fontSize="16px">
-                font-family: -apple-system, BlinkMacSystemFont, San Francisco,
-                Segoe UI, Roboto, Helvetica Neue, sans-serif;
+                font-family: ui-sans-serif, system-ui, -apple-system,
+                BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+                "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+                "Segoe UI Symbol", "Noto Color Emoji";
               </Text>
-            </Box>
-
-            <Box mt="36px">
-              <Body size="l">
-                We also utilize the following classes to improve legibility.
-              </Body>
-
-              <Box mt="m" padding="l" as="pre" bg="#F5F6F7">
-                <Text fontSize="16px" as="pre">
-                  -webkit-font-smoothing: antialiased;
-                </Text>
-                <Text fontSize="16px" as="pre">
-                  -moz-osx-font-smoothing: grayscale;
-                </Text>
-              </Box>
             </Box>
           </Box>
         </Box>


### PR DESCRIPTION
This updates our system font stack to [match Tailwind’s](https://tailwindcss.com/docs/font-family), which is a bit more robust. For example, it includes the newer `ui-sans-serif` value.

The suggestion to use `font-smoothing` is also removed. It’s a non-standard property that works inconcistently across browsers and operating systems. With modern font technology like variable fonts and lots of new CSS typography features, `font-smoothing` isn’t really needed.

This change was also made in the Buoy Design System Figma file.